### PR TITLE
xml > voisenon_moliere_orig > quote

### DIFF
--- a/xml/voisin_defense-traite_1671.xml
+++ b/xml/voisin_defense-traite_1671.xml
@@ -59,7 +59,9 @@
       <sourceDesc>
         <bibl>Joseph de Voisin, <hi rend="i">La défense du traité de Monseigneur le Prince de
             Conti</hi>, <pubPlace>Paris</pubPlace>, <publisher>Coignard</publisher>,
-            <date>1671</date>. </bibl>
+            <date>1671</date>. PDF : <!--<ref
+              target="https://books.google.fr/books?id=yzEWX14dMwIC&hl=fr&source=gbs_navlinks_s"
+            >Google Book</ref>-->. </bibl>
       </sourceDesc>
     </fileDesc>
     <profileDesc>
@@ -163,7 +165,7 @@
           funestes, qu’il mériterait d’être enseveli dans un oubli éternel. <pb n="ix" xml:id="pix"
           />Il suffit de savoir que dans un dérèglement si général, ce jeune Prince n’eut pas la
           force de résister au torrent, et à la violence des tentations qui l’environnaient.
-            <quote>« II pécha, comme les Princes ont accoutumé de faire ; mais il fit pénitence, ce
+            <quote>« Il pécha, comme les Princes ont accoutumé de faire ; mais il fit pénitence, ce
             que les Princes n’ont pas coutume de faire<note place="margin" resp="author">S.
               Ambrosius Apologia I. David. cap. 2.</note> »</quote> : de sorte qu’on peut dire que
           cette chute est devenue le sujet de son Eloge, puisqu’elle a servi à l’humilier devant
@@ -1838,7 +1840,7 @@
           <div>
             <head>Dissertation pag. 2.</head>
             <p><quote>« Tous les Jeux, et les Spectacles de l’Antiquité ont fait la plus grande, et
-                  la plus solennelle partie de la Religion Païenne. »</quote></p>
+                la plus solennelle partie de la Religion Païenne. »</quote></p>
           </div>
           <div>
             <head>Première Observation.</head>
@@ -2281,31 +2283,30 @@
                   nous instruisent beaucoup mieux ; car ils ont cet avantage, et cette utilité,
                   qu’ils nous font voir que ce qu’ils nous proposent, n’est pas impossible. En effet
                   quelle terreur eût jamais été capable de faire ce qu’a fait le respect, et la
-                  vénération qu’on a pour votre Majesté ? Un de nos Princes
-                  (Domitien<note>[NDA] Insertion de l’auteur.</note>) obtint à <pb n="13"
-                    xml:id="p13"/>la vérité des Romains qu’ils souffrissent qu’on abolît les
-                  Spectacles des Pantomimes ; mais il ne put obtenir que ce fût de leur plein gré
-                  qu’ils y consentissent. Il n’en est pas de même de vous ; car ils sont venus
-                  d’eux-mêmes vous supplier de leur accorder ce que ce Prince exigeait d’eux par
-                  force : et ils ont reçu comme un bienfait, ce qui leur était autrefois une
-                  nécessité de souffrir malgré qu’ils en eussent. Car tout le Peuple vous conjura
-                  d’une commune voix d’abolir les Spectacles des Pantomimes avec autant
-                  d’empressement qu’il en avait témoigné à votre Père lorsqu’il le supplia de les
-                  vouloir rétablir. Il y a eu en cette rencontre de la justice de part et d’autre.
-                  Car il fallait rétablir ces Jeux, parce qu’un méchant Prince les avait ôtés, et il
-                  fallait les abolir après les avoir rétablis. C’est ainsi qu’on doit se conduire à
-                  l’égard des bons règlements que les mauvais Princes ont faits, afin qu’il paraisse
-                  que ce n’est pas l’action qu’on improuve ; mais que c’est à cause qu’on n’en peut
-                  supporter l’Auteur. Ce peuple donc qui se plaisait autrefois à voir jouer un
-                  Empereur sur le Théâtre, et qui lui donnait des applaudissements, est à présent le
-                  même qui se déclare contre les Pantomimes, et qui condamne ces Jeux infâmes, et
-                  ces divertissements honteux à notre siècle. Cela nous fait connaître clairement,
-                  que le menu peuple même est capable de se régler sur la bonne vie du Prince, et
-                  que tout le monde se porte à la vertu, quelque sévère qu’elle soit, lorsque le
-                  Prince la pratique. Continuez donc, ô César, cette sérieuse conduite qui vous
-                  attire tant de vénération et de respect, que ce qu’on ne faisait auparavant que
-                  par force et par crainte, on le fait maintenant par l’amour de la vertu et des
-                  bonnes mœurs. »</quote></p>
+                  vénération qu’on a pour votre Majesté ? Un de nos Princes (Domitien<note>[NDA]
+                    Insertion de l’auteur.</note>) obtint à <pb n="13" xml:id="p13"/>la vérité des
+                  Romains qu’ils souffrissent qu’on abolît les Spectacles des Pantomimes ; mais il
+                  ne put obtenir que ce fût de leur plein gré qu’ils y consentissent. Il n’en est
+                  pas de même de vous ; car ils sont venus d’eux-mêmes vous supplier de leur
+                  accorder ce que ce Prince exigeait d’eux par force : et ils ont reçu comme un
+                  bienfait, ce qui leur était autrefois une nécessité de souffrir malgré qu’ils en
+                  eussent. Car tout le Peuple vous conjura d’une commune voix d’abolir les
+                  Spectacles des Pantomimes avec autant d’empressement qu’il en avait témoigné à
+                  votre Père lorsqu’il le supplia de les vouloir rétablir. Il y a eu en cette
+                  rencontre de la justice de part et d’autre. Car il fallait rétablir ces Jeux,
+                  parce qu’un méchant Prince les avait ôtés, et il fallait les abolir après les
+                  avoir rétablis. C’est ainsi qu’on doit se conduire à l’égard des bons règlements
+                  que les mauvais Princes ont faits, afin qu’il paraisse que ce n’est pas l’action
+                  qu’on improuve ; mais que c’est à cause qu’on n’en peut supporter l’Auteur. Ce
+                  peuple donc qui se plaisait autrefois à voir jouer un Empereur sur le Théâtre, et
+                  qui lui donnait des applaudissements, est à présent le même qui se déclare contre
+                  les Pantomimes, et qui condamne ces Jeux infâmes, et ces divertissements honteux à
+                  notre siècle. Cela nous fait connaître clairement, que le menu peuple même est
+                  capable de se régler sur la bonne vie du Prince, et que tout le monde se porte à
+                  la vertu, quelque sévère qu’elle soit, lorsque le Prince la pratique. Continuez
+                  donc, ô César, cette sérieuse conduite qui vous attire tant de vénération et de
+                  respect, que ce qu’on ne faisait auparavant que par force et par crainte, on le
+                  fait maintenant par l’amour de la vertu et des bonnes mœurs. »</quote></p>
               <p>Enfin si nous considérons comment les Jeux et les Spectacles faisaient partie de la
                 Religion Païenne, nous verrons que la proposition de l’Auteur de la Dissertation
                 n’est nullement soutenable : <quote>« Que tous les Jeux et les Spectacles de
@@ -2340,16 +2341,16 @@
                 solennité des Fêtes ; puisqu’il n’y avait point de Fêtes sans sacrifice, comme le
                 nom même de Férie nous le fait entendre, qui vient, selon Festus<note place="margin"
                   resp="author">
-                  <p><quote>« Feria a feriendis victimis appellata. <!--[NC]-->
-                    Ferias antiqui festas vocabant. »</quote> Festus.</p>
-                </note>, <quote><hi rend="i">a feriendis victimis</hi></quote>, c’est-à-dire, de ce
-                qu’on immolait en ces jours des victimes aux Dieux. Au lieu qu’il y avait une
+                  <quote><l>« Feria a feriendis victimis appellata.</l>
+                    <l>Ferias antiqui festas vocabant. <hi rend="i">Festus</hi>. »</l></quote>
+                </note>, <quote>« <hi rend="i">a feriendis victimis</hi> »</quote>, c’est-à-dire, de
+                ce qu’on immolait en ces jours des victimes aux Dieux. Au lieu qu’il y avait une
                 infinité de Fêtes sans Jeux, et sans Spectacles : et qu’ils ne rendaient point
                 solennels les jours auxquels il n’y avait point de sacrifice. Car il y avait des
                 Jeux et des Spectacles les jours ouvriers, ainsi qu’on le peut apprendre par ces
                 paroles de l’Empereur Julien l’Apostat<note place="margin" resp="author"
                     ><quote>« Semper odi Circenses, perinde ut forum qui obstricti sunt ære alieno.
-                    Itaque raro ad eos venio, nempe in Deorum festo</quote>. » Julian. in <hi
+                    Itaque raro ad eos venio, nempe in Deorum festo. »</quote> Julian. in <hi
                     rend="i">Misopog.</hi></note> : <quote>« J’ai toujours autant fui les Jeux du
                   Cirque, que ceux qui sont chargés de beaucoup de dettes, fuient la place publique.
                   C’est pourquoi je n’y vais que rarement ; à savoir les jours de Fête. »</quote>
@@ -2533,7 +2534,7 @@
                 pas venir à Rome pour tenir les assemblées, il nommât dans le territoire de Rome un
                 Dictateur pour les tenir : et comme le même ordre portait, que si le Consul s’était
                 retiré à Tarente, le Préteur Q. Claudius conduisît les troupes en un lieu d’où il
-                pût plus aisément défendre un plus grand nombre de villes alliées » </quote>; Le
+                pût plus aisément défendre un plus grand nombre de villes alliées »</quote> ; Le
               Consul voyant que le Préteur ne pourrait se trouver à Rome pour faire les Jeux, il
               élut Manlius Dictateur pour tenir les assemblées et pour faire les Jeux : mais c’était
               principalement pour tenir les assemblées, selon l’ordre du Sénat.</p>
@@ -2558,7 +2559,7 @@
                       anno A. Cornelius fuerit. Id ambigitur belline gerendi causa creatus sit, an
                       ut esset qui ludis Romanis, quia L. Plautius Prætor gravi morbo forte
                       implicitus erat, signa mittendis quadrigis daret ; functusque eo haud sane
-                      memorandi Imperii ministerio, se dictatura abdicaret</quote>. » Tit. Liv. in
+                      memorandi Imperii ministerio, se dictatura abdicaret. »</quote> Tit. Liv. in
                     fin. l. 8.</note>,</seg> qu’en cette année A. Cornélius n’ait été Dictateur ;
                 mais on doute s’il fût créé Dictateur pour faire la guerre ; ou s’il le fût
                 seulement afin que le Préteur L. Plautius étant travaillé d’une grande maladie, il y
@@ -2717,11 +2718,11 @@
                       >Apolog</hi>. c. 38.</note>,</seg> comme nous en condamnons les diverses
                 origines par la connaissance que nous avons que ce sont des effets de la
                 superstition et de d’Idolâtrie. »</quote></p>
-            <p><quote> «  Vous qui êtes Chrétiens,<seg type="exquote"> dit-il en un autre
-                    endroit<note resp="author" place="margin"><quote>« Oderis, Christiane, quorum
-                      authores non potes non odisse. »</quote> Idem de <hi rend="i">Spectacul</hi>.
-                    c. 10.</note>,</seg> haïssez et détestez ces choses, dont les Auteurs ne peuvent
-                être que l’objet de votre haine, et de votre aversion. »</quote>
+            <p><quote>« Vous qui êtes Chrétiens,<seg type="exquote"> dit-il en un autre endroit<note
+                    resp="author" place="margin"><quote>« Oderis, Christiane, quorum authores non
+                      potes non odisse. »</quote> Idem de <hi rend="i">Spectacul</hi>. c.
+                  10.</note>,</seg> haïssez et détestez ces choses, dont les Auteurs ne peuvent être
+                que l’objet de votre haine, et de votre aversion. »</quote>
             </p>
             <p><quote>« Un serviteur de Dieu<seg type="exquote">, dit-il encore<note place="margin"
                     resp="author"><quote>« Non sola ista conciliabula spectaculorum, sed etiam
@@ -2781,7 +2782,7 @@
             <head>I. Observation.</head>
             <p>Ce que l’Auteur de la Dissertation dit en cet endroit, étant fidèlement rapporté
               suffit pour détruire sa proposition.</p>
-            <p><quote> «  Anciennement<seg type="exquote">, dit Suidas<note resp="author"
+            <p><quote>« Anciennement<seg type="exquote">, dit Suidas<note resp="author"
                     place="margin"><quote>« Olim carminibus in Bac chum scriptis certebant, quæ et
                       Satirica dicebantur. Postea vero ad Tragedias scribendas aggressi, paulatim ad
                       fabulas et historias se converterunt, nullam Bacchi amplius mentionem
@@ -2845,17 +2846,17 @@
                 place="margin" resp="author">Dans la 1. Observation sur le 1. chapitre.</note>. Cela
               était si connu que les Poètes mêmes l’ont publié. <quote>« Les femmes<seg
                   type="exquote">, dit Ovide<note place="margin" resp="author"><p><quote>« Spectatum
-                        veniunt, veniunt spectentur ut ipsæ.</quote></p><p><quote>Ille locus casti
-                        damna pudoris habet. »</quote></p><p> Ovid. lib. 1. <hi rend="i">de arte
-                        amandi.</hi></p></note></seg>, vont au Théâtre pour voir, et pour y être
-                vues. Ce lieu cause la ruine de la chasteté, et de la pudeur. »</quote></p>
+                        veniunt, veniunt spectentur ut ipsæ. »</quote></p><p><quote>« Ille locus
+                        casti damna pudoris habet. »</quote></p><p> Ovid. lib. 1. <hi rend="i">de
+                        arte amandi.</hi></p></note></seg>, vont au Théâtre pour voir, et pour y
+                être vues. Ce lieu cause la ruine de la chasteté, et de la pudeur. »</quote></p>
             <p>Et dans un autre endroit.</p>
             <p><pb n="28" xml:id="p28"/><quote>« Qu’on ôte<seg type="exquote">, dit-il<note
                     place="margin" resp="author"><p><quote>« Tollatur circus, nam tuta licentia non
-                        est.</quote></p>
-                    <p><quote>Hic sedet ignoto juncta puella viro. »</quote></p><p>Idem lib. 2. <hi
-                        rend="i">Trist.</hi></p></note>,</seg> le Cirque, car la licence y est si
-                grande, que l’honneur des filles n’y est pas en sûreté, étant assises auprès des
+                        est. »</quote></p>
+                    <p><quote>« Hic sedet ignoto juncta puella viro. »</quote></p><p>Idem lib. 2.
+                        <hi rend="i">Trist.</hi></p></note>,</seg> le Cirque, car la licence y est
+                si grande, que l’honneur des filles n’y est pas en sûreté, étant assises auprès des
                 hommes qui leur sont inconnus. »</quote></p>
 
             <p>Il ne s’ensuit pas non plus de ce que les Comédies et les Tragédies étaient
@@ -2865,15 +2866,15 @@
               seulement en cet endroit, que selon le témoignage d’Ovide<note place="margin"
                 resp="author"><quote>« Ludi quoque semina prebent nequitiæ. »</quote> Ovid. lib. 2.
                   <hi rend="i">Trist.</hi></note>, <quote>« ces Jeux jettent dans l’âme les semences
-                du vice »,  »</quote>, Et que selon Properce<note resp="author" place="margin">
+                du vice »</quote>, Et que selon Properce<note resp="author" place="margin">
                 <quote>« Illic te multi potentur corrumpere ludi. »</quote> Idem lib. 2. <hi
                   rend="i">Eleg.</hi> [NDE] L’attribution correcte serait Properce, lib. 2.
-                Eleg.</note> ;<quote> « Les jeux du Théâtre corrompent les bonnes mœurs. C’est
+                Eleg.</note> ; <quote>« Les jeux du Théâtre corrompent les bonnes mœurs. C’est
                 pourquoi on ne jouait point de Comédies, ni de Tragédies parmi les Lacédémoniens,
                 pour ne point écouter, non pas même en se jouant, ceux qui parlaient contre les
                   Lois<note place="margin" resp="author"><quote>« Comedias et Tragedias non
                     admittebant Lacones, ut neque serio, neque joco, eos qui legibus contradicerent,
-                    audirent. »</quote> Plutarch. De instituit. Lacon.</note> . »</quote></p>
+                    audirent. »</quote> Plutarch. De instituit. Lacon.</note>. »</quote></p>
             <p>Nous lisons dans la vie de Platon, qu’ayant fait dans la maturité de son âge des
               Tragédies comme il allait les réciter sur le Théâtre, il rencontra Socrate qui le
               toucha tellement par ses discours, qu’il jeta aussitôt ses Tragédies dans le feu,
@@ -2882,7 +2883,7 @@
                     quas cum in Dionysii Theatro recitaturus esset, in Socratem incidit, et ejus
                     Syrene delinitus Philosophiæ opera dare cœpit, poëmata igni tradidit, inquiens.
                     hic, ô Vulcane, Plato tua ope indiger. »</quote> Diogen. Laert. in <hi rend="i"
-                    >vitat. Platoni</hi>s.</note> . »</quote></p>
+                    >vitat. Platoni</hi>s.</note>. »</quote></p>
             <p>De sorte que tant s’en faut que Platon crût que ses Tragédies fussent des actes de
               religion, qu’au contraire il fut persuadé que c’était faire un acte de religion, que
               de les sacrifier à Vulcain, et de les brûler.</p>
@@ -2890,11 +2891,10 @@
           <div>
             <head>Dissertation pag. 44. et 45.</head>
             <p>
-              <quote>« Et Valère dit</quote>
-              <note place="margin" resp="author"><quote>« Excogitata cultus Deorum et hominum
-                  delectationis causa. »</quote> Valer. Max. lib. 2. cap. 4.</note>
-              <quote> que les Théâtres ont été inventés pour rendre honneur aux Dieux, et donner du
-                plaisir aux hommes. »</quote>
+              <quote>« Et Valère dit <note place="margin" resp="author"><quote>« Excogitata cultus
+                    Deorum et hominum delectationis causa. »</quote> Valer. Max. lib. 2.
+                  cap. 4.</note> que les Théâtres ont été inventés pour rendre honneur aux Dieux, et
+                donner du plaisir aux hommes. »</quote>
             </p>
           </div>
           <div>
@@ -2946,10 +2946,9 @@
                   ><quote>« Quibusdam videtur esse nonnunquam de jucunditate sola consultatio : ut
                   si de ædificando Theatro, instituendis ludis deliberetur. Sed neminem adeo solutum
                   luxu puto, ut nihil in causa suadendi sequatur præter voluptatem. Præcedat enim
-                  semper aliquid necesse est, ut in ludis</quote>
-                <quote>honor Deorum ; in Theatro non inutilis laborum remissio, deformis, et
-                  incommoda turbæ, si id non sit, conflictatio. »</quote> Quintil. lib. 3. cap. 8.
-              </note>.</p>
+                  semper aliquid necesse est, ut in ludis honor Deorum ; in Theatro non inutilis
+                  laborum remissio, deformis, et incommoda turbæ, si id non sit,
+                  conflictatio. »</quote> Quintil. lib. 3. cap. 8. </note>.</p>
             <p>
               <quote>« Il y en a qui estiment qu’on peut quelquefois fonder une délibération sur le
                 seul plaisir ; comme lorsqu’on délibère si l’on doit bâtir un Théâtre et instituer
@@ -2958,25 +2957,26 @@
                 nécessairement qu’il y ait toujours quelque autre motif qui précède, savoir celui de
                 l’honneur des Dieux en ce qui regarde les Jeux ; et à l’égard du Théâtre, celui de
                 l’utilité que produit le relâche du travail ; ce qui serait désagréable et incommode
-                au peuple à cause de la presse, s’il n’y avait point de Théâtre.</quote>
+                au peuple à cause de la presse, s’il n’y avait point de Théâtre. »</quote>
             </p>
-            <p><quote>Nous y ajoutons aussi le motif de la Religion, en disant que le Théâtre est
+            <p><quote>« Nous y ajoutons aussi le motif de la Religion, en disant que le Théâtre est
                 comme une espèce de Temple, où l’on rend aux Dieux ces honneurs sacrés<note
-                  place="margin" resp="author">« Et nihilominus eadem illa religio, cum Theatrum
-                  veluti quoddam illius sacri templum vocabimus. »</note> »</quote>, c’est-à-dire,
-              où l’on fait des Jeux à l’honneur des Dieux. Voilà ce que dit Quintilien. Y a-t-il
-              rien qui en soit plus éloigné, que ce que lui fait dire l’Auteur de la Dissertation ?
-              Quintilien dit que celui qui voudrait persuader qu’on doit instituer des Jeux, ne
-              devrait pas seulement représenter qu’on le doit, parce que cela est divertissant ;
-              mais qu’il faudrait représenter quelque autre motif précédent, disant qu’on le doit
-              faire ; parce que c’est rendre un honneur aux Dieux que d’instituer des Jeux : Et
-              l’Auteur de la Dissertation fait dire à Quintilien, <quote>« Que la célébration des
-                Jeux sacrés commence toujours par l’honneur des Dieux ».</quote></p>
+                  place="margin" resp="author"><quote>« Et nihilominus eadem illa religio, cum
+                    Theatrum veluti quoddam illius sacri templum
+                vocabimus. »</quote></note> »</quote>, c’est-à-dire, où l’on fait des Jeux à
+              l’honneur des Dieux. Voilà ce que dit Quintilien. Y a-t-il rien qui en soit plus
+              éloigné, que ce que lui fait dire l’Auteur de la Dissertation ? Quintilien dit que
+              celui qui voudrait persuader qu’on doit instituer des Jeux, ne devrait pas seulement
+              représenter qu’on le doit, parce que cela est divertissant ; mais qu’il faudrait
+              représenter quelque autre motif précédent, disant qu’on le doit faire ; parce que
+              c’est rendre un honneur aux Dieux que d’instituer des Jeux : Et l’Auteur de la
+              Dissertation fait dire à Quintilien, <quote>« Que la célébration des Jeux sacrés
+                commence toujours par l’honneur des Dieux ».</quote></p>
             <p>Quintilien dit que pour persuader de bâtir un Théâtre, on doit encore alléguer le
               motif de la Religion, en disant que le Théâtre est comme une espèce de Temple où l’on
               fait des Jeux à l’honneur des Dieux ; et l’Auteur de la Dissertation lui fait dire :
                 <quote>« Que c’est <pb n="31" xml:id="p31"/>un sentiment de Religion de nommer le
-                Théâtre un Temple, ou un Sanctuaire</quote> ».</p>
+                Théâtre un Temple, ou un Sanctuaire ».</quote></p>
             <p>Ainsi ce que Quintilien propose comme un exemple d’une matière de délibération et par
               conséquent comme une chose douteuse (car comme il dit dans le même chapitre,
                 <quote>« Toute délibération est d’une chose douteuse<note place="margin"
@@ -3046,7 +3046,7 @@
                   toutes les autres. »</quote>
               </p>
               <p>
-                <quote>Les uns disaient que Pompée même avait été repris par les vieillards de son
+                <quote>« Les uns disaient que Pompée même avait été repris par les vieillards de son
                   temps pour avoir fondé un Théâtre perpétuel ; car auparavant on n’en dressait qu’à
                   mesure qu’on en avait à faire. Et dans les commencements de Rome le peuple
                   assistait aux spectacles tout debout. On disait qu’en faisant des sièges, on avait
@@ -3059,58 +3059,55 @@
                   et prenait leurs plaisirs, leurs exercices, et leurs sales amours, par l’autorité
                   du Prince, et du Sénat, qui ne se contentaient pas de souffrir les vices mais les
                   commandaient. Que les principaux sous ombre de faire des vers et des harangues,
-                  montaient déjà sur le Théâtre : et qu’il ne leur restait plus qu’à </quote>
-                <pb n="33" xml:id="p33"/>
-                <quote>descendre tout nus en l’arène, et de prendre le Ceste au lieu de la cuirasse
-                  et de l’épée. Que les Augures n’apprendraient pas à vivre saintement, et les
-                  Chevaliers à devenir bons Juges, en ne s’étudiant qu’à savoir toute la mollesse
-                  des tons, et des nombres de la Musique. Qu’on avait même choisi la nuit pour
-                  accroître l’infamie, et pour ne laisser aucun asile à la pudeur ; et qu’il était
-                  bien facile aux débauchés parmi la confusion, et les ténèbres, d’exécuter les
-                  convoitises du jour, et les adultères prémédités pendant la lumière. »</quote>
+                  montaient déjà sur le Théâtre : et qu’il ne leur restait plus qu’à<pb n="33"
+                    xml:id="p33"/> descendre tout nus en l’arène, et de prendre le Ceste au lieu de
+                  la cuirasse et de l’épée. Que les Augures n’apprendraient pas à vivre saintement,
+                  et les Chevaliers à devenir bons Juges, en ne s’étudiant qu’à savoir toute la
+                  mollesse des tons, et des nombres de la Musique. Qu’on avait même choisi la nuit
+                  pour accroître l’infamie, et pour ne laisser aucun asile à la pudeur ; et qu’il
+                  était bien facile aux débauchés parmi la confusion, et les ténèbres, d’exécuter
+                  les convoitises du jour, et les adultères prémédités pendant la lumière. »</quote>
               </p>
             </div>
             <div>
               <head>Raisons pour persuader qu’il est raisonnable d’instituer des Jeux, et bâtir un
                 théâtre.</head>
               <p>
-                <quote>« D’autres trouvaient</quote>
-                <note place="margin" resp="author"><quote>« Pluribus ipsa licentia placebat : ac
-                    tamen honesta nomina prætendebant : Majores quoque non abhorruisse spectaculorum
-                    oblectamentis, pro fortuna quæ tunc erat ; eoque ad Thuscis accitos histriones,
-                    ad Thuriis equorum certamina : et possessa Achaia, Asiaque ludos curatius
-                    editos. Neque quamquam Romæ honesto loco ortum, ad Theatrales artes
-                    degeneravisse ducentis jam annis a L. Mummii triumpho, qui primus id genus
-                    spectaculi in urbe præbuerit, sed et consultum parsimoniæ ; quod perpetua sedes
-                    theatro locata sit, potius quam immenso sumptu singulos per annos consurgeret ac
-                    strueretur : nec perinde Magistratus rem familiarem exhausturos, aut populo
-                    efflagitandi Græca certamina ad Magistratibus causam fore, cum eo sumptu
-                    respublica fungatur. Oratorum ac Vatum victorias incitamentum ingeniis
-                    allaturas : Nec cuiquam Judici grave aures studiis honestis et voluptatibus
-                    concessis impartire : lætitiæ magis, quam lasciviæ dari paucas totius
-                    quinquennii noctes, quibus tanta luce ignium nihil illicitum occultati
-                    queat. »</quote></note>
-                <quote> même cette licence agréable ; mais ils déguisaient leurs vices sous des noms
-                  honnêtes : ils disaient que la sévérité de nos Ancêtres, n’avait pas même été
-                  ennemie du divertissement des Spectacles, et qu’ils en avaient tout le soin, qu’on
-                  en pouvait avoir alors : Qu’ils avaient envoyé quérir en Toscane des farceurs et
-                  des baladins, et tiré d’un autre endroit les plaisirs du Cirque : Qu’étant maîtres
-                  de la Grèce et de l’Asie, ils avaient fait leurs jeux avec plus d’appareil ; et
-                  que cela avait apporté si peu de corruption, qu’en l’espace de deux cents ans
-                  qu’il y avait depuis le triomphe de Mummius, qui avait introduit ces plaisirs dans
-                  Rome, il ne s’était trouvé personne d’honnête famille qui fût monté sur le
-                  Théâtre. Qu’en établissant un lieu perpétuel pour les exercices, on avait eu égard
-                  à l’épargne, à cause des dépenses infinies qu’il fallait faire tous les ans pour
-                  ce sujet. Que le peuple ne demanderait plus ces jeux aux Magistrats, et ne les
-                  ruinerait plus pour les donner, comme il faisait auparavant, depuis que la
-                  République en aurait fait la dépense. Que les combats de la prose, et de la poésie
-                  servaient d’aiguillon aux beaux esprits ; et qu’un juge ne perdrait rien de sa
-                  gravité pour donner quelques heures de récréation aux voluptés honnêtes et
-                  permises. Que c’était plus pour allégresse publique que par amour de la débauche
-                  qu’on destinait quelques nuits tous les </quote>
-                <pb n="34" xml:id="p34"/>
-                <quote>cinq ans à ces exercices : et que parmi tant de feux, et de clartés, il était
-                  difficile qu’il s’y pût rien passer de déshonnête. »</quote>
+                <quote>« D’autres trouvaient <note place="margin" resp="author"><quote>« Pluribus
+                      ipsa licentia placebat : ac tamen honesta nomina prætendebant : Majores quoque
+                      non abhorruisse spectaculorum oblectamentis, pro fortuna quæ tunc erat ; eoque
+                      ad Thuscis accitos histriones, ad Thuriis equorum certamina : et possessa
+                      Achaia, Asiaque ludos curatius editos. Neque quamquam Romæ honesto loco ortum,
+                      ad Theatrales artes degeneravisse ducentis jam annis a L. Mummii triumpho, qui
+                      primus id genus spectaculi in urbe præbuerit, sed et consultum parsimoniæ ;
+                      quod perpetua sedes theatro locata sit, potius quam immenso sumptu singulos
+                      per annos consurgeret ac strueretur : nec perinde Magistratus rem familiarem
+                      exhausturos, aut populo efflagitandi Græca certamina ad Magistratibus causam
+                      fore, cum eo sumptu respublica fungatur. Oratorum ac Vatum victorias
+                      incitamentum ingeniis allaturas : Nec cuiquam Judici grave aures studiis
+                      honestis et voluptatibus concessis impartire : lætitiæ magis, quam lasciviæ
+                      dari paucas totius quinquennii noctes, quibus tanta luce ignium nihil
+                      illicitum occultati queat. »</quote></note> même cette licence agréable ; mais
+                  ils déguisaient leurs vices sous des noms honnêtes : ils disaient que la sévérité
+                  de nos Ancêtres, n’avait pas même été ennemie du divertissement des Spectacles, et
+                  qu’ils en avaient tout le soin, qu’on en pouvait avoir alors : Qu’ils avaient
+                  envoyé quérir en Toscane des farceurs et des baladins, et tiré d’un autre endroit
+                  les plaisirs du Cirque : Qu’étant maîtres de la Grèce et de l’Asie, ils avaient
+                  fait leurs jeux avec plus d’appareil ; et que cela avait apporté si peu de
+                  corruption, qu’en l’espace de deux cents ans qu’il y avait depuis le triomphe de
+                  Mummius, qui avait introduit ces plaisirs dans Rome, il ne s’était trouvé personne
+                  d’honnête famille qui fût monté sur le Théâtre. Qu’en établissant un lieu
+                  perpétuel pour les exercices, on avait eu égard à l’épargne, à cause des dépenses
+                  infinies qu’il fallait faire tous les ans pour ce sujet. Que le peuple ne
+                  demanderait plus ces jeux aux Magistrats, et ne les ruinerait plus pour les
+                  donner, comme il faisait auparavant, depuis que la République en aurait fait la
+                  dépense. Que les combats de la prose, et de la poésie servaient d’aiguillon aux
+                  beaux esprits ; et qu’un juge ne perdrait rien de sa gravité pour donner quelques
+                  heures de récréation aux voluptés honnêtes et permises. Que c’était plus pour
+                  allégresse publique que par amour de la débauche qu’on destinait quelques nuits
+                  tous les<pb n="34" xml:id="p34"/> cinq ans à ces exercices : et que parmi tant de
+                  feux, et de clartés, il était difficile qu’il s’y pût rien passer de
+                  déshonnête. »</quote>
               </p>
               <p>Il y a cette différence entre l’exemple de Quintilien, et celui de Tacite que dans
                 cette délibération sur le sujet des Jeux et du Théâtre, Tacite n’allègue point d’une
@@ -3142,23 +3139,22 @@
             <head>Dissertation pag. 51. 52. et 53.</head>
             <p>
               <quote>« En quoi certes il ne faut pas dire que les Anciens se moquaient de ceux
-                qu’ils adoraient comme Dieux, en représentant </quote>
-              <pb n="35" xml:id="p35"/>
-              <quote>des actions que l’on pouvait nommer criminelles, comme des meurtres, des
-                adultères, et des vengeances : ni qu’ils avaient dessein d’en faire des objets de
-                Jeux et de risée, en leur imputant des crimes que l’on condamnait parmi les hommes,
-                car toutes ces choses étaient mystérieuses, et bien que le petit peuple ignorant et
-                grossier fût peut-être incapable de porter sa croyance au-delà des fables que l’on
-                en contait ; il est certain que leurs Théologiens, leurs Philosophes, et tous les
-                gens d’esprit en avaient bien d’autres pensées. Et tout ce que nous lisons
-                maintenant de la naissance de leurs Dieux, et de toutes leurs actions avait une
-                intelligence mystique, ou dans les secrètes opérations de la nature, ou dans les
-                belles maximes de la morale, ou dans les merveilles incompréhensibles de la
-                Divinité. Nous l’apprenons de la <hi rend="i">Poétique</hi> d’Aristote, des
-                allégories d’Héraclide Ponticus, des Saturnales de Macrobe, de Maxime de Tir, de
-                Cicéron, de Sénèque, de Léon Hébreu, de Lilius Giraldus, et de tous les Auteurs des
-                Mythologies. Ce qui nous découvre que tout ce qui se faisait dans le Théâtre et tout
-                ce qui s’y disait touchant les faux Dieux, était des actes de révérence. »</quote>
+                qu’ils adoraient comme Dieux, en représentant<pb n="35" xml:id="p35"/> des actions
+                que l’on pouvait nommer criminelles, comme des meurtres, des adultères, et des
+                vengeances : ni qu’ils avaient dessein d’en faire des objets de Jeux et de risée, en
+                leur imputant des crimes que l’on condamnait parmi les hommes, car toutes ces choses
+                étaient mystérieuses, et bien que le petit peuple ignorant et grossier fût peut-être
+                incapable de porter sa croyance au-delà des fables que l’on en contait ; il est
+                certain que leurs Théologiens, leurs Philosophes, et tous les gens d’esprit en
+                avaient bien d’autres pensées. Et tout ce que nous lisons maintenant de la naissance
+                de leurs Dieux, et de toutes leurs actions avait une intelligence mystique, ou dans
+                les secrètes opérations de la nature, ou dans les belles maximes de la morale, ou
+                dans les merveilles incompréhensibles de la Divinité. Nous l’apprenons de la <hi
+                  rend="i">Poétique</hi> d’Aristote, des allégories d’Héraclide Ponticus, des
+                Saturnales de Macrobe, de Maxime de Tir, de Cicéron, de Sénèque, de Léon Hébreu, de
+                Lilius Giraldus, et de tous les Auteurs des Mythologies. Ce qui nous découvre que
+                tout ce qui se faisait dans le Théâtre et tout ce qui s’y disait touchant les faux
+                Dieux, était des actes de révérence. »</quote>
             </p>
           </div>
           <div>
@@ -3222,11 +3218,11 @@
                   lasciviam lex tribut. »</quote> Aristotel. 7. <hi rend="i">Politic</hi>. cap.
                 17.</note>.</p>
             <p>
-              <quote>Comme nous avons défendu toutes sortes de paroles déshonnêtes, il est évident
+              <quote>« Comme nous avons défendu toutes sortes de paroles déshonnêtes, il est évident
                 que nous défendons aussi de regarder des peintures, ou des actions déshonnêtes, et
                 honteuses. Que les Magistrats aient donc soin qu’on ne fasse point de peintures, ni
                 de statues qui représentent ces impuretés ; si ce n’est pour le culte de quelques
-                Dieux, s’il y en a de tels, dont les lois autorisent l’impudicité.</quote>
+                Dieux, s’il y en a de tels, dont les lois autorisent l’impudicité. »</quote>
             </p>
             <p>Sur quoi un savant Interprète d’Aristote a fait cette excellente remarque<note
                 place="margin" resp="author"><quote>« Quod subjungit Aristoteles, nisi apud quosdam
@@ -3306,12 +3302,12 @@
             <p><quote>« Les Poètes<seg type="exquote">, dit S. Augustin<note place="margin"
                     resp="author"><quote>« Multa et ipsi (Poëtæ) ad eundem modum interpretati sunt
                         (<hi rend="i">ut ostendantur rerum significare naturam</hi>) usque adeo ut
-                      quod ab eis immanissimum, et infandissimum dicitur ; Saturnum</quote>
-                    <quote>suos filios devorasse ; ita non nulli interpretentur, quod longinquitas
-                      temperis, quæ Saturni nomine significatur, quidquid gignit, ipsa consumat :
-                      vel sicut idem opinatur Varro, quod pertineat Saturnus ad semina, quæ in
-                      terram de qua oriuntur, iterum recidunt. Itemque alii alio modo ; et similiter
-                      cætera. Et tamen Theologia fabulosa dicitur, et cum omnibus hujuscemodi
+                      quod ab eis immanissimum, et infandissimum dicitur ; Saturnum suos filios
+                      devorasse ; ita non nulli interpretentur, quod longinquitas temperis, quæ
+                      Saturni nomine significatur, quidquid gignit, ipsa consumat : vel sicut idem
+                      opinatur Varro, quod pertineat Saturnus ad semina, quæ in terram de qua
+                      oriuntur, iterum recidunt. Itemque alii alio modo ; et similiter cætera. Et
+                      tamen Theologia fabulosa dicitur, et cum omnibus hujuscemodi
                       interpretationibus suis reprehenditur, abjicitur, improbatur : nec solum a
                       naturali, quæ Philosophorum est ; verum etiam ab ista civili, de qua agitur,
                       quæ ad urbes, populosque pertinere asseritur, eo quod de Diis indigna
@@ -3383,31 +3379,33 @@
                       explicatur : eorumque unum mythicon, seu fabulosum appellari ; alterum
                       physicon, seu naturale ; tertium civile. »</quote> Varro apud S. August. lib.
                     6. <hi rend="i">de civit. Dei</hi>, cap. 5.</note>
-                  <note place="margin" resp="author"> «  <quote>Myticon appellant quo maxime utuntur
-                      Poëtæ, Physicon, quo Philosophi : civile, quo populi.  »</quote> Ibid. </note>
-                  <note place="margin" resp="author"> «  <quote>Prima, inquit, Theologia maxime
-                      accomodata est ad Theatrum : secunda ad mundum : tertia ad urbem. »</quote>
-                    Ibid. </note>
-                  <note place="margin" resp="author"> «  <quote>Primum, inquit Varro, quod dixi in
-                      eo sunt multa contra dignitatem, et naturam immortalium ficta : in hoc enim
-                      est, ut Deus alius ex capite, alius ex femore sit, alius ex guttis sanguinis
-                      natus. In hoc ut Dii furati sint, ut adulteraverint, ut servierint homini.
-                      Denique in hoc omnia Diis attribuuntur, quæ non modo in hominem, sed etiam quæ
-                      in contemptissimum hominem cadere possunt.  »</quote> Ibid. </note>
-                  <note place="margin" resp="author"> «  <quote>Quam fabulosam Theologiam libere a
-                      se Varro putavit esse culpandam. »</quote> Ibid. </note> qu’il y a trois
-                  genres de Théologie, c’est-à-dire, de discours qui traitent des Dieux, dont l’un
-                  est la Théologie fabuleuse, l’autre la naturelle, et le troisième la
-                  civile.</quote>
+                  <note place="margin" resp="author">
+                    <quote>« Myticon appellant quo maxime utuntur Poëtæ, Physicon, quo Philosophi :
+                      civile, quo populi.  »</quote> Ibid. </note>
+                  <note place="margin" resp="author">
+                    <quote>« Prima, inquit, Theologia maxime accomodata est ad Theatrum : secunda ad
+                      mundum : tertia ad urbem. »</quote> Ibid. </note>
+                  <note place="margin" resp="author">
+                    <quote>« Primum, inquit Varro, quod dixi in eo sunt multa contra dignitatem, et
+                      naturam immortalium ficta : in hoc enim est, ut Deus alius ex capite, alius ex
+                      femore sit, alius ex guttis sanguinis natus. In hoc ut Dii furati sint, ut
+                      adulteraverint, ut servierint homini. Denique in hoc omnia Diis attribuuntur,
+                      quæ non modo in hominem, sed etiam quæ in contemptissimum hominem cadere
+                      possunt.  »</quote> Ibid. </note>
+                  <note place="margin" resp="author">
+                    <quote>« Quam fabulosam Theologiam libere a se Varro putavit esse
+                      culpandam. »</quote> Ibid. </note> qu’il y a trois genres de Théologie,
+                  c’est-à-dire, de discours qui traitent des Dieux, dont l’un est la Théologie
+                  fabuleuse, l’autre la naturelle, et le troisième la civile. »</quote>
               </p>
               <p>
                 <quote>« La Théologie fabuleuse est celle dont se servent principalement les
                   Poètes : la naturelle est celle dont se servent les Philosophes : la civile est
-                  celle dont se servent les peuples.</quote>
+                  celle dont se servent les peuples. »</quote>
               </p>
               <p>
                 <quote>« La Théologie fabuleuse regarde particulièrement le Théâtre : la naturelle
-                  regarde le monde : la civile regarde les villes.</quote>
+                  regarde le monde : la civile regarde les villes. »</quote>
               </p>
               <p>
                 <quote>« Quant au premier genre de Théologie, c’est-à-dire, quant à la Théologie
@@ -3443,17 +3441,17 @@
                   particulier dans les écoles, qu’en public, où tout le monde n’est pas capable
                   d’entendre ces choses : Varron n’improuve rien<seg type="exquote">, dit
                     S. Augustin,</seg> dans ce genre de Théologie qu’il appelle naturelle, et qui
-                  appartient aux Philosophes.</quote>
+                  appartient aux Philosophes. »</quote>
               </p>
               <p>
-                <quote>Le troisième genre de Théologie <seg type="exquote">, dit Varron <note
+                <quote>« Le troisième genre de Théologie <seg type="exquote">, dit Varron <note
                       place="margin" resp="author"><quote>« Tertium genus est, inquit, quod in
                         urbibus cives, maxime sacerdotes nosse atque administrare debent ; in quo
                         est, quos Deos publice colere, quæ Sacra, et sacrificia facere quemque par
                         fit. »</quote> Ibid.</note>,</seg> est celui que les citoyens, et
                   principalement les Prêtres doivent savoir, et pratiquer dans les villes. Elle
                   enseigne quels Dieux il faut adorer publiquement ; quelles cérémonies, et quels
-                  sacrifices chacun doit faire.</quote>
+                  sacrifices chacun doit faire. »</quote>
               </p>
               <p> Varron ajoute <note place="margin" resp="author"><quote>« Ait enim Varro, ea quæ
                     scribunt Poëtæ, minus esse quam ut populi sequi debeant. quæ vero Philosophi,
@@ -3594,13 +3592,13 @@
               <p>L’unique but de la Comédie est de donner du plaisir, comme le Prologue de l’<hi
                   rend="i">Andrienne</hi> de Térence nous le fait assez connaître en ces termes<note
                   place="margin" resp="author"><p><quote>« Poëta cum primum animum ad scribendum
-                      appulit. </quote></p><p><quote>Id sibi negotii credidit solum
-                    dari.</quote></p><p><quote>Populo ut placerent quas fecisset fabulas. »</quote>
-                    Teren. In Prol. Andr.</p></note> : <quote>« Lorsque le Poète s’est mis à écrire,
-                  il a cru que la seule chose qu’il avait à faire, était de rendre ses Comédies
-                  agréables au peuple. »</quote> Et c’est une des principales raisons qui fait que
-                la Philosophie les rejette. <quote>« Il y a des fables<seg type="exquote">, dit
-                      Macrobe<note resp="author" place="margin">
+                      appulit. »</quote></p><p><quote>« Id sibi negotii credidit solum
+                      dari. »</quote></p><p><quote>« Populo ut placerent quas fecisset
+                      fabulas. »</quote> Teren. In Prol. Andr.</p></note> : <quote>« Lorsque le
+                  Poète s’est mis à écrire, il a cru que la seule chose qu’il avait à faire, était
+                  de rendre ses Comédies agréables au peuple. »</quote> Et c’est une des principales
+                raisons qui fait que la Philosophie les rejette. <quote>« Il y a des fables<seg
+                    type="exquote">, dit Macrobe<note resp="author" place="margin">
                       <quote>« Fabulæ auditum mulcent, velut Comœdiæ, quales Menander, ejusve
                         imitatores agendas dederunt : vel argumenta fictis casibus amatorum referta,
                         quibus vel multum se arbiter exerevit, vel Apuleieum nonnunquam lusisse
@@ -3667,7 +3665,7 @@
                         <l>Quem contra amari, quem accersiri,quem expeti. »</l>
                       </lg>
                     </quote>
-                  </note>.</quote>
+                  </note>. »</quote>
               </p>
               <quote>
                 <l>« Qui ne croit pas qu’Amour soit des Dieux le plus grand,</l>
@@ -3684,26 +3682,26 @@
                       putet ! De Comœdia loquor, quæ si hæc flagitia non probaremus, nulla esset
                       omnino. Quid autem ex Tragedia princeps ille Argonautarum ? »</quote>
                     Ibid.</note>, laquelle place dans l’assemblée des Dieux, l’amour qui est
-                  l’auteur du vice, de l’extravagance, et de la légèreté ?</quote></p>
+                  l’auteur du vice, de l’extravagance, et de la légèreté ? »</quote></p>
               <p><quote>« J’entends parler de la Comédie, qui ne pourrait subsister, et qui serait
                   il y a déjà longtemps exterminée, si nous n’approuvions toutes ces ordures et ces
-                  vilénies. Mais que dit dans la Tragédie le Prince des Argonautes ?</quote>
+                  vilénies. Mais que dit dans la Tragédie le Prince des Argonautes ? »</quote>
               </p>
               <p>
                 <quote>« L’amour plus que l’honneur t’oblige à me sauver<note resp="author"
                     place="margin"> <quote>« Tu me amoris magis, quam honoris servasti
-                      gratia. »</quote></note>. </quote></p>
+                      gratia. »</quote></note>. »</quote></p>
               <p>
-                <quote>Combien l’amour de Médée a-t-il causé d’embrasements et de misères<note
+                <quote>« Combien l’amour de Médée a-t-il causé d’embrasements et de misères<note
                     place="margin" resp="author"><quote>« Quid ergo hic amor Medeæ quanta miseriarum
                       incendia excitavit ? Atque ea tamen apud alium Poëtam patri dicere audet se
                       conjugem habuisse. »</quote>
                     <quote>« Illum amor quem dederat, qui plus pollet, potiorque est
                       patre. »</quote></note> ? Cette femme furieuse ose dire à son père, dans un
                   autre Poète, qu’elle ne reconnaît pour son mari que celui <quote>« Que lui donna
-                    l’amour plus puissant que son père »</quote>. »</quote></p>
+                    l’amour plus puissant que son père ».</quote> »</quote></p>
               <p>
-                <quote>Mais laissons les Poètes<note resp="author" place="margin"><quote>« Sed
+                <quote>« Mais laissons les Poètes<note resp="author" place="margin"><quote>« Sed
                       Poëtas ludere sinamus, quorum fabulis in hoc flagitio versari ipsum videmus
                       Jovem. »</quote> Ibid.</note> se jouer dans les fables, où nous voyons même
                   Jupiter souillé de ce vice, et esclave de l’amour. »</quote>
@@ -3721,9 +3719,9 @@
                 <l>Quand on fait ce qu’il faut pour avoir du succès. »</l>
               </quote>
               <p><quote>« Ces vers<seg type="exquote">, dit encore Cicéron,<note place="margin"
-                      resp="author">«<quote>Qui est versus omnium seminator
+                      resp="author"><quote>« Qui est versus omnium seminator
                       malorum. »</quote></note>,</seg> sont comme une semence de toutes sortes de
-                  méchancetés, et de maux. </quote></p>
+                  méchancetés, et de maux. »</quote></p>
 
               <quote>
                 <l>« Il a donné lui-même à mon ressentiment<note resp="author" place="margin"><quote>
@@ -3737,7 +3735,8 @@
                 <l>Suivons la passion dont je suis combattue,</l>
                 <l>Je me perds, il est vrai, mais au moins je le tue. »</l>
               </quote>
-              <p> « <quote>Considérez ce qu’elle fait en fuyant son père et son pays</quote><note
+              <p>
+                <quote>« Considérez ce qu’elle fait en fuyant son père et son pays »</quote><note
                   resp="author" place="margin"><quote>« Atque eadem Medea patrem, patriamque
                     fugiens. »</quote></note> : </p>
               <quote>
@@ -3778,12 +3777,13 @@
                       place="margin">
                       <quote>
                         <lg>
-                          <l>Major mihi moles, majus miseriarum est malum, </l>
-                          <l>Qui illius acerbum cor contundam et comprimam.</l>
-                        </lg></quote></note>, </l>
+                          <l>« Major mihi moles, majus miseriarum est malum, </l>
+                          <l>Qui illius acerbum cor contundam et comprimam. »</l>
+                        </lg>
+                      </quote></note>, </l>
                   <l> Pour dompter de son cœur les infâmes transports. </l>
                 </lg></quote>
-              <p>  «<quote>Il ne faut pas pourtant oublier Thyeste même<note> Nec tamen ille ipse
+              <p>  <quote>« Il ne faut pas pourtant oublier Thyeste même<note> Nec tamen ille ipse
                     est prætermittendus qui nec sat habuit conjugem illexisse in stuprum, de quo
                     recte, et verissime loquitur <hi rend="i">Atreus</hi>.</note>, qui ne se
                   contente pas de corrompre la femme de son frère ; sur quoi Atrée dit fort
@@ -3807,7 +3807,7 @@
                     </note></l>
 
                   <l><pb n="48" xml:id="p48"/> C’est de souiller des Rois la maison, et le rang </l>
-                  <l> C’est de confondre enfin et la race, et le sang. </l>
+                  <l> C’est de confondre enfin et la race, et le sang. »</l>
                 </lg>
               </quote>
 
@@ -3834,7 +3834,8 @@
                   raison ? Le Théâtre est rempli de semblables crimes <note place="margin"
                     resp="author">« <quote>Videtur ne summa improbitate usus, non sine summa esse
                       ratione ? Scena referta est his sceleribus. »</quote> Cic. lib. 3. <hi
-                      rend="i">de nat. Deorum.</hi></note></quote>. » </p>
+                      rend="i">de nat. Deorum.</hi></note>. »</quote>
+              </p>
               <p>Diogène Laërce raconte<note place="margin" resp="author"><quote>« Euripide ita de
                     virtute disserente, ut diceret præclarum esse temere eam dimittere ; surgens
                     egressus est, turpe esse dicens, mancipium si non inveniatur, dignum
@@ -3848,7 +3849,7 @@
               <p><quote>« Que dirons-nous<seg type="exquote">, dit Cicéron<note resp="author"
                       place="margin">
                       <quote>« Quid levitates Comicæ ? »</quote> Cicero lib. 3. <hi rend="i">de nat.
-                        Deorum.</hi></note>,</seg>des extravagances de la Comédie</quote> ? » En
+                        Deorum.</hi></note>,</seg>des extravagances de la Comédie ? »</quote> En
                 voici un exemple tiré d’une Comédie intitulée <hi rend="i">Les Synéphèbes</hi> ; qui
                 instruit les fils de famille à dérober leur père, par des fourbes, par des
                 tromperies, et par de mauvais traitements. Un débauché parle en ces termes dans
@@ -3920,7 +3921,7 @@
                   son pays, après l’avoir gouverné tant d’années ; et en paix et en guerre, avec
                   tant d’éclat et de gloire ; c’est ce qui est aussi peu supportable, que si nos
                   Comiques Plaute, Névius, et Cécilius eussent eu l’insolence d’outrager les deux
-                  Scipion, et Caton même.</quote></p>
+                  Scipion, et Caton même. »</quote></p>
               <p><pb n="50" xml:id="p50"/><quote>« Il ajoute peu après<note place="margin"
                     resp="author"><quote>« Deinde paulo post : nostræ, inquit, contra duodecim
                       Tabulæ, cum perpaucas res capite sanxissent ; in his hanc quoque sanciendam
@@ -3938,12 +3939,12 @@
                   pas être en proie à la licence des Poètes : et il ne doit point être permis de
                   nous dire une injure, sinon à condition que nous y puissions répondre, et que nous
                   ayons la liberté de nous en défendre, et d’appeler l’autorité publique à notre
-                  secours...</quote></p>
+                  secours... »</quote></p>
               <p>
                 <quote>« Cicéron passe ensuite à d’autres discours ; et pour conclure il montre
                   enfin que les anciens Romains ne pouvaient souffrir qu’un homme vivant fût ni
-                  loué, ni blâmé sur le Théâtre</quote>
-                <note place="margin" resp="author">« …<quote>Dicit deinde alia ; et sic concludit
+                  loué, ni blâmé sur le Théâtre »</quote>
+                <note place="margin" resp="author"><quote>« …Dicit deinde alia ; et sic concludit
                     hunc locum, ut ostendat veteribus disciplicuisse Romanis, vel laudari quemquam
                     in scena vivum hominem, vel vituperari. »</quote> Idem.</note>
               </p>
@@ -3960,7 +3961,8 @@
                   rien de ce qui regarde le culte religieux qui leur est dû. Mais je soutiens qu’on
                   doit entièrement abolir une chose qu’on y joint, laquelle a été accordée au peuple
                   par condescendance, et qui déplaît extrêmement aux honnêtes gens : à savoir les
-                  discours injurieux, et diffamatoires, et tous ces jeux des Comédies...</quote></p>
+                  discours injurieux, et diffamatoires, et tous ces jeux des
+                Comédies... »</quote></p>
               <p>
                 <quote>« N’est-il pas raisonnable <note place="margin" resp="author">Texte en
                     grec.</note> qu’aux jours de Fête nous ayons un grand soin de ne nous entretenir
@@ -3972,7 +3974,7 @@
                   plus cher et plus agréable aux Dieux, que le soin que nous prenons de leur
                   présenter notre cœur aussi pur qu’il nous est possible : et quelle plus grande
                   preuve peut-on donner de la vénération qui leur est due, que de ne rien dire, et
-                  de ne rien écouter d’indécent en leur présence ?...</quote>
+                  de ne rien écouter d’indécent en leur présence ?... »</quote>
               </p>
               <p>
                 <quote>« Il y en a <note place="margin" resp="author">Texte en grec.</note> qui ont
@@ -3982,7 +3984,7 @@
                   Pour moi, s’il était possible d’instruire ainsi les hommes, j’estimerais que
                   l’ivrognerie y serait encore plus propre : Mais il est bien difficile de croire
                   que des ivrognes pussent donner aux autres des instructions pour devenir sages, et
-                  devant que d’être désenivrés, apprendre aux autres à bien vivre...</quote>
+                  devant que d’être désenivrés, apprendre aux autres à bien vivre... »</quote>
               </p>
               <p>
                 <quote>« Nous savons tous <note place="margin" resp="author">Texte en grec.</note>
@@ -4002,7 +4004,7 @@
                   maisons ? Et cependant nous abandonnerons la conduite des enfants, des femmes, du
                   peuple, et en un mot, des Magistrats à quiconque s’en voudra mêler ; et nous nous
                   confierons à des ivrognes que nous condamnons lorsqu’ils sont encore à
-                  jeun ?</quote>
+                  jeun ? »</quote>
               </p>
               <p>
                 <quote>« Que si nous considérons <note place="margin" resp="author">Texte en
@@ -4010,7 +4012,7 @@
                   qu’on célèbre pendant toute la nuit ; certes c’est un temps de divertissement, et
                   non pas d’étude. Est-il donc raisonnable que lorsque nos enfants sortent de
                   l’école de leurs véritables Précepteurs, ils aillent sous d’autres qui n’en ont
-                  point la charge, et qui s’ingèrent eux-mêmes de leur faire des leçons ?</quote>
+                  point la charge, et qui s’ingèrent eux-mêmes de leur faire des leçons ? »</quote>
               </p>
               <p>
                 <quote>« Quant au lieu <note place="margin" resp="author">Texte en grec.</note>
@@ -4019,14 +4021,14 @@
                   n’est point aux Théâtres où les Précepteurs doivent aller pour instruire leurs
                   disciples ; puisque les Théâtres ne sont établis que pour le plaisir, et le
                   divertissement. Mais il y a d’autres lieux qui sont destinés pour l’étude de la
-                  sagesse, comme leur nom le marque....</quote>
+                  sagesse, comme leur nom le marque... »</quote>
               </p>
               <p>
                 <quote>« Je n’estime point aussi <note place="margin" resp="author">Texte en
                     grec.</note> que ce soit une manière propre à instruire la jeunesse, de railler,
                   et de noircir la réputation d’autrui avec impudence ; mais la jeunesse doit être
                   élevée, ainsi qu’il convient à des personnes libres ; et sur toutes choses on lui
-                  doit apprendre à se garder de rien faire qui soit indécent.</quote>
+                  doit apprendre à se garder de rien faire qui soit indécent. »</quote>
               </p>
               <p>
                 <quote>« Ceux qui n’ont point l’honneur en recommandation <note place="margin"
@@ -4038,17 +4040,17 @@
                   donc pas permettre la Comédie afin que vos enfants en deviennent meilleurs ; mais
                   c’est pour cette raison, quand il n’y en aurait point d’autre, qu’on doit abolir
                   la Comédie, afin que vos enfants puissent librement s’exercer dans la vertu, sans
-                  crainte d’être joués sur le Théâtre.</quote>
+                  crainte d’être joués sur le Théâtre. »</quote>
               </p>
               <p>
                 <quote>« N’est-il donc pas tout à fait évident <note place="margin" resp="author"
                     >Texte en grec.</note> que la Comédie est <pb n="53" xml:id="p53"/> très
-                  odieuse, et qu’il vaut mieux l’abolir entièrement ?</quote>
+                  odieuse, et qu’il vaut mieux l’abolir entièrement ? »</quote>
               </p>
               <p>
                 <quote>« Quels sont ceux <note place="margin" resp="author">Texte en grec.</note>
                   qu’on représente dans la Comédie, tels sont d’ordinaire tous ceux qui se plaisent
-                  à ces représentations.</quote>
+                  à ces représentations. »</quote>
               </p>
               <p>
                 <quote>« Où y a-t-il plus de malignité dans la diction <note place="margin"
@@ -4131,7 +4133,7 @@
                       ><quote>« Quid enim aliud ostendunt illa simulacra, formæ, ætates, sexus,
                       habitus Deorum ? »</quote>
                   </note>,</seg> des Dieux, leurs formes, leurs âges, leurs sexes, leurs postures,
-                et leurs ornements, nous en fournissent assez de preuves.</quote>
+                et leurs ornements, nous en fournissent assez de preuves. »</quote>
             </p>
             <p>
               <quote>« N’y a-t-il que les Poètes qui représentent Jupiter avec une barbe<note
@@ -4258,20 +4260,18 @@
                   et plus considérables que dans l’Idolâtrie ? De sorte que si les Spectacles en
                   sont procédés, et soutenus, il ne faut point douter qu’ils ne soient compris en
                   cette renonciation générale. Or il est aisé de vous le justifier <pb n="59"
-                    xml:id="p59"/> par leur origine, et leur accroissement</quote> : par leurs
+                    xml:id="p59"/> par leur origine, et leur accroissement »</quote> : par leurs
                 représentations accompagnées de mille superstitions <note place="margin"
                   resp="author"><quote>« Exinde apparatus, quibus superstitionibus
-                    instruantur. »</quote></note>
-                <quote>«  : par ceux qui président dans tous les lieux destinés à ces
-                  magnificences : et par les inventeurs des arts qui s’y
-                pratiquent. »</quote></quote>
+                    instruantur. »</quote></note> : par ceux qui président dans tous les lieux
+                destinés à ces magnificences : et par les inventeurs des arts qui s’y
+                pratiquent. »</quote>
             </p>
             <p>
               <quote>« Et après avoir traité toutes ces choses séparément et doctement, il poursuit.
-                  <note place="margin" resp="author">Ibid. cap. 8.</note>
-                <quote>« Regarde donc, Chrétien, les noms des esprits immondes qui se sont emparés
-                  du Cirque, tu ne dois point avoir de part à cette Religion, où tant de démons sont
-                  les maîtres. »</quote></quote>
+                  <note place="margin" resp="author">Ibid. cap. 8.</note>« Regarde donc, Chrétien,
+                les noms des esprits immondes qui se sont emparés du Cirque, tu ne dois point avoir
+                de part à cette Religion, où tant de démons sont les maîtres. »</quote>
             </p>
             <p>
               <quote>« Enfin il ajoute :<quote>« le Théâtre est le vrai sanctuaire de Vénus et de
@@ -4284,7 +4284,7 @@
                   qu’il nous soit libre d’y participer ni par les actions ni par les regards.
                   Personne ne se jette ni dans le camp, ni dans le parti des ennemis sans avoir
                   abandonné les armes et les enseignes sous lesquelles il
-                combattait. »</quote></quote>
+                combattait. »</quote> »</quote>
             </p>
             <p>
               <quote>« Aussi lorsque l’on exorcisa cette femme qui se trouva possédée d’un démon à
@@ -4298,7 +4298,7 @@
                 d’assister à leurs spectacles, il dit en un mot : <note place="margin" resp="author"
                   >In <hi rend="i">Apolog.</hi> cap. 38.</note>
                 <quote>« Nous y renonçons parce que nous savons bien qu’ils sont les ouvrages de la
-                  Superstition. »  »</quote></quote>
+                  Superstition. »</quote> »</quote>
             </p>
             <div>
               <head>Suite de la Réfutation.</head>
@@ -4472,7 +4472,7 @@
                         essent quæ illo modo videbantur honorandæ memoriæ defunctorum. Idem ipsum
                         unum quod ubique poneret, circumferebat quo jam non solum aquatissimo, sed
                         etiam tepidissimo cum suis præsentibus per sorbitiones esiguas partiretur,
-                        quia pietatem ibi quærebat, non voluptatem.</quote></p>
+                        quia pietatem ibi quærebat, non voluptatem. »</quote></p>
                     <p><quote>« Itaque ubi comperit a præclaro prædicatore, atque Antistite pietatis
                         præceptum esse, ista non fieri, nec ab eis qui sobrie facerent, ne ulla
                         occasio se ingurgitandi daretur ebriosi ; et quia illa quasi parentalia,
@@ -4752,10 +4752,10 @@
                 Spectacles, les Jeux, et les autres divertissements semblables, qui sont des restes
                 du Paganisme, sont contraires à la discipline Chrétienne ; combien ils sont
                 exécrables, et détestables ; combien de maux et d’afflictions publiques ils attirent
-                sur le peuple Chrétien.</quote></p>
+                sur le peuple Chrétien. »</quote></p>
             <p>
-              <quote>Et pour en persuader leurs auditeurs, ils emploieront les raisons dont se sont
-                servis ces grands personnages Tertullien, saint Cyprien Martyr, Salvien, et
+              <quote>« Et pour en persuader leurs auditeurs, ils emploieront les raisons dont se
+                sont servis ces grands personnages Tertullien, saint Cyprien Martyr, Salvien, et
                 S. Chrysostome ; ils n’omettront rien sur ce sujet de ce qui peut contribuer à
                 détruire entièrement ces dérèglements et ces débauches. »</quote>
             </p>
@@ -4779,7 +4779,7 @@
                 honteux et détestable que l’on y rendait aux démons ; Mais que cette raison qui fut
                 autrefois si puissante dans la bouche des Pères de l’Eglise, n’est plus maintenant
                 considérable ; et que cette défense qu’ils prêchaient avec quelque sorte d’anathème,
-                n’a plus ce fondement dans notre siècle.</quote></p>
+                n’a plus ce fondement dans notre siècle. »</quote></p>
             <p><quote>« Et si tous ceux<seg type="exquote">, dit-il<note resp="author"
                     place="margin"> Dissert. pag. 93.</note>,</seg> qui se sont opiniâtrement
                 attachés à combattre le Théâtre par les paroles de nos anciens Pères, eussent bien
@@ -4909,7 +4909,7 @@
                     Traitté de la Comedie et des Spectacles</hi> pag. 113. et 114. S. August. in
                   psal. 102. </note> ? Ne sont-ce pas des hommes à qui ils donnent ? Mais ils ne
                 considèrent pas en eux la nature de l’ouvrage de Dieu ; ils ne regardent que
-                l’iniquité de l’ouvrage de l’homme.</quote>
+                l’iniquité de l’ouvrage de l’homme. »</quote>
             </p>
             <p>
               <quote>« Qu’est-ce que donner à l’ouvrage de l’homme<note resp="author" place="margin"
@@ -5043,13 +5043,12 @@
                     dit-il<note place="margin" resp="author"><quote>« Hippodromum ad omnem
                       elegantiam perpolivit Constantinus, cujus partem fecit Castoris et Pollucis
                       ædem, quorum simulachra nunc etiam in porticibus Hippodromi stantia videre
-                      licet,</quote>
-                    <quote>statui et in quadam Hippodromi parte Apollinis Delphici Tripodem, ipsius
-                      Apollinis simulachrum in se continentem. »</quote> Zozim. l. 2.</note>,</seg>
-                embellit beaucoup le Cirque, et il y enferma le Temple de Castor et de Pollux, dont
-                on voit encore maintenant les statues sur les portiques du Cirque ; il mit encore en
-                un autre endroit du même lieu le Trépied d’Apollon de Delphes, qui porte sa
-                figure. »</quote></p>
+                      licet, statui et in quadam Hippodromi parte Apollinis Delphici Tripodem,
+                      ipsius Apollinis simulachrum in se continentem. »</quote> Zozim. l.
+                  2.</note>,</seg> embellit beaucoup le Cirque, et il y enferma le Temple de Castor
+                et de Pollux, dont on voit encore maintenant les statues sur les portiques du
+                Cirque ; il mit encore en un autre endroit du même lieu le Trépied d’Apollon de
+                Delphes, qui porte sa figure. »</quote></p>
             <p>Nous voyons donc que le Cirque, quoiqu’il fût consacré à de fausses divinités,
               quoiqu’il fût rempli de plusieurs statues de faux Dieux, n’était pas estimé un lieu
               religieux pour y faire des actes d’adoration, puisque l’Empereur Constantin ayant ôté
@@ -5107,18 +5106,16 @@
           <div>
             <head>Dissertation pag. 96. et 97.</head>
             <p>
-              <quote>« Pourquoi voudrait-on traiter les Poèmes dramatiques</quote>
-              <pb n="80" xml:id="p80"/>
-              <quote>avec plus de rigueur que les autres spectacles de l’antiquité, que les
-                Empereurs Chrétiens ont entretenus longtemps, après leur avoir ôté tout ce qu’ils
-                avaient du Paganisme ? Ils en firent les divertissements de leur Cour, et de leurs
-                peuples, quand les Fidèles y purent assister sans entrer dans la société des
-                Idolâtres. Constantin ayant embrassé le Christianisme, défendit les Jeux des
-                Gladiateurs, comme une brutalité criminelle sans excuse, et qui ne pouvait se
-                rectifier : et ayant donné les jeux Circenses avec grande pompe, il en retrancha
-                toute la superstition, et toute la révérence des Idoles, afin qu’ils fussent dignes
-                des Chrétiens ; et ils furent conservés ainsi jusques au règne des
-                Comnènes. »</quote>
+              <quote>« Pourquoi voudrait-on traiter les Poèmes dramatiques<pb n="80" xml:id="p80"/>
+                « avec plus de rigueur que les autres spectacles de l’antiquité, que les Empereurs
+                Chrétiens ont entretenus longtemps, après leur avoir ôté tout ce qu’ils avaient du
+                Paganisme ? Ils en firent les divertissements de leur Cour, et de leurs peuples,
+                quand les Fidèles y purent assister sans entrer dans la société des Idolâtres.
+                Constantin ayant embrassé le Christianisme, défendit les Jeux des Gladiateurs, comme
+                une brutalité criminelle sans excuse, et qui ne pouvait se rectifier : et ayant
+                donné les jeux Circenses avec grande pompe, il en retrancha toute la superstition,
+                et toute la révérence des Idoles, afin qu’ils fussent dignes des Chrétiens ; et ils
+                furent conservés ainsi jusques au règne des Comnènes. »</quote>
             </p>
           </div>
           <div>
@@ -5131,7 +5128,7 @@
                 place="margin" resp="author">Dissertation pag. 69.</note> : <quote>« Quand le
                 Concile 3. de Carthage défend à tous les Chrétiens de donner les spectacles publics,
                 et d’y assister, <seg type="exquote">il est ajouté</seg>  ; Parce qu’ils ne doivent
-                point se trouver où sont les blasphémateurs du nom de Dieu. </quote></p>
+                point se trouver où sont les blasphémateurs du nom de Dieu. »</quote></p>
             <p><quote>« Et saint Chrysostome se réjouissant de voir le Cirque et le Théâtre
                 abandonné par les Chrétiens, et les Eglises plus fréquentées que par le passé<note
                   place="margin" resp="author">Dissertation pag. 69. et 70.</note>, <quote>« Combien
@@ -5142,7 +5139,7 @@
                   qui leur sont défendues, et qui font partie de cette assemblée diabolique, formée
                   contre la plénitude de l’Eglise de Dieu. Mais sans nous en mêler davantage,
                   l’Orchestre, et le Cirque sont maintenant déserts, et tous viennent ici pour
-                  chanter les louanges de Dieu. »  »</quote></quote></p>
+                  chanter les louanges de Dieu. »</quote> »</quote></p>
             <p>
               <pb n="81" xml:id="p81"/>
               <quote>« Les Conciles ont interdit <note place="margin" resp="author">Dissert. pag.
@@ -5150,7 +5147,7 @@
                 considération la communion aux Fidèles qui conduisaient les chariots dans les
                 combats du Cirque ; car ces conducteurs de chariots ne pouvaient être coupables que
                 pour être participants de l’Idolâtrie ; et il traite les Scéniques et les Histrions
-                comme Apostats.</quote>
+                comme Apostats. »</quote>
             </p>
             <p><quote>« Orose n’avait point d’autre sentiment<note place="margin" resp="author"
                   >Dissert. pag. 71. Oros. lib. 4.</note>, lorsque parlant des Théâtres Romains dans
@@ -5158,7 +5155,7 @@
                   les fréquentent ; c’est blasphémer le nom de Dieu qui les défend, c’est honorer
                   ces Dieux abominables, c’est-à-dire les démons qui les demandent, et qui par un
                   effet de leur malice y veulent des sacrifices, où l’on fait mourir plus de vertus
-                  que de victimes, etc. »  »</quote></quote> Et l’Auteur de la Dissertation, après
+                  que de victimes, etc. »</quote> »</quote> Et l’Auteur de la Dissertation, après
               avoir rapporté plusieurs semblables témoignages de S Chrysostome, de S. Augustin et de
               Salvien, conclut en ces termes<note place="margin" resp="author">Dissert. pag.
                 87.</note> : <quote>« Voilà comme ils en parlent tous ; et cette sévérité fut si
@@ -5244,8 +5241,8 @@
                         mundus ? Ubi populus acceptabilis ? Ubi populus boni operis ? Ubi populus
                         sanctitatis ? <quote>« Christus, <seg type="exquote">inquit Scriptura</seg>,
                           pro nobis passus est, nobis exemplum relinquens ut sequamur vestigia
-                          ejus</quote>.” Vidilicet vestigia Salvatoris sequimur in Circo ; vestigia
-                        Salvatori sequimur in Theatro ?</quote></p>
+                          ejus »</quote>. Vidilicet vestigia Salvatoris sequimur in Circo ; vestigia
+                        Salvatori sequimur in Theatro ? »</quote></p>
                     <p><quote>«  Tale nobis scilicet et Christus reliquit exemplum, quem flevisse
                         legimus, risisse non legimus ? et hoc utrumque pro nobis, quia fletus
                         compunctio est cordis, risus corruptio disciplinæ ; et ideo dicebat :
@@ -5279,7 +5276,7 @@
                 la componction du cœur, et le ris vient de la corruption, et du dérèglement de la
                 discipline. C’est pourquoi il disait ; <quote>« Malheur à vous qui riez maintenant,
                   parce que vous serez réduits aux pleurs et aux larmes : et vous êtes bienheureux,
-                  vous qui pleurez maintenant, parce que vous rirez. »  »</quote></quote></p>
+                  vous qui pleurez maintenant, parce que vous rirez. »</quote> »</quote></p>
             <div>
               <head>Avertissement.</head>
               <p>Pour garder l’ordre de la Chronologie, je rapporte ici l’exemple de l’Empereur
@@ -5291,9 +5288,8 @@
             <head>Dissertation. pag. 98.</head>
             <p>
               <quote>« Constantius donna dans Arles les jeux Circenses, et du Théâtre, avec grande
-                magnificence</quote>
-              <note place="margin" resp="author">Ammian. Marcell. l. 14.</note>
-              <quote>. »</quote>
+                magnificence <note place="margin" resp="author">Ammian. Marcell. l.
+                14.</note>. »</quote>
             </p>
           </div>
           <div>
@@ -5346,7 +5342,7 @@
                 œuvres, et à toutes vos pompes… Les pompes du diable sont les spectacles du Théâtre,
                 et toutes les autres vanités semblables, dont le Roi David demande à Dieu d’être
                 délivré : <quote>« Détournez, <seg type="exquote">dit-il,</seg> mes yeux, afin
-                  qu’ils ne regardent point la vanité. »  »</quote></quote>.</p>
+                  qu’ils ne regardent point la vanité. »</quote> »</quote>.</p>
           </div>
           <div>
             <pb n="86" xml:id="p86"/>
@@ -5370,16 +5366,16 @@
                     susceptis filiis in Ecclesia et traditis Sacerdoti, in hac luce fuit. »</quote>
                   Paulinus in vita S. Ambrosii.</note>, après avoir reçu ses enfants dans l’Eglise,
                 et après les avoir recommandés à l’Evêque, ne vécut pas longtemps. » « Nous voyons
-                par là</quote>, dit Baronius<note place="margin" resp="author"><quote>« Ex quo
-                  erroris arguuntur Socrates et Sozomenes, dum aiunt filios Constantinopoli
-                  advenientes reperisse ipsum Theodosium morbo laborantem in lecto. »</quote> Baron.
-                ad ann. 395.</note>, <quote>que Socrate et Sozomène se sont trompés, disant que les
-                enfants de Théodose venant de Constantinople, le trouvèrent au lit malade dans
-                Milan ; car Paulin qui y était présent, dit qu’ils le trouvèrent à l’Eglise, où il
-                les reçut, et les recommanda à S. Ambroise. »</quote> Quoiqu’il en soit, Socrate et
-              Sozomène ne disent point que Théodose approuvât ces Spectacles, ni qu’il les jugeât
-              dignes des Chrétiens. Je sais bien que Zozime a écrit que l’Empereur Théodose avait
-              une extrême passion pour les Spectacles : <quote>« Tout ce qui contribue beaucoup<seg
+                par là, dit Baronius<note place="margin" resp="author"><quote>« Ex quo erroris
+                    arguuntur Socrates et Sozomenes, dum aiunt filios Constantinopoli advenientes
+                    reperisse ipsum Theodosium morbo laborantem in lecto. »</quote> Baron. ad ann.
+                  395.</note>, que Socrate et Sozomène se sont trompés, disant que les enfants de
+                Théodose venant de Constantinople, le trouvèrent au lit malade dans Milan ; car
+                Paulin qui y était présent, dit qu’ils le trouvèrent à l’Eglise, où il les reçut, et
+                les recommanda à S. Ambroise. »</quote> Quoiqu’il en soit, Socrate et Sozomène ne
+              disent point que Théodose approuvât ces Spectacles, ni qu’il les jugeât dignes des
+              Chrétiens. Je sais bien que Zozime a écrit que l’Empereur Théodose avait une extrême
+              passion pour les Spectacles : <quote>« Tout ce qui contribue beaucoup<seg
                   type="exquote"> , dit-il<note place="margin" resp="author"><quote>« Omnia
                       quæcumque corrumpendis moribus et vitæ plurimum valent, hoc imperante Principe
                       tantum incrementi cœperunt, ut prope modum omnes, qui studia Principis
@@ -5393,7 +5389,7 @@
                 exécrables : et tous ces exercices qui sont pleins d’impuretés, avec tout ce qui
                 appartient à la licence et aux dérèglements de la Musique, étaient en usage <pb
                   n="87" xml:id="p87"/>sous le règne de ce Prince et de ses
-              successeurs</quote>. »</p>
+              successeurs. »</quote></p>
             <p>Mais si les Spectacles du temps de l’Empereur Théodose étaient tels que Zozime les
                 dépeint<note place="margin" resp="author"><quote>« Musicam pertinent, tam sub ipso
                   quam deinceps exercitum est. »</quote> Zozim. lib. 4.</note>, l’Auteur de la
@@ -5480,27 +5476,24 @@
             <head>Dissertation pag. 97. et 98.</head>
             <p>
               <quote>« Les Empereurs Honorius, et Arcadius Chrétiens donnèrent les jeux du Cirque
-                avec les Tragédies et les Comédies</quote>
-              <note place="margin" resp="author">Claudian. lib. 2. in Eutrop. Hi tragicos
-                meminere.</note>
-              <quote> ; ce que le Proconsul Manlius Théodorus fit encore sous leur règne dans l’an
-                de sa Magistrature. Aussi quand Arcadius, Honorius, Théodosius voulurent régler les
-                Jeux et les Spectacles publics, qu’ils nommèrent les délices et la joie du peuple,
-                ils n’en défendirent pas absolument la célébration ; mais ils en retranchèrent tous
-                les sacrifices et toutes les superstitions du Paganisme ; et voici comme ils en
-                écrivirent au Proconsul d’Afrique Apollodorus</quote>
-              <note place="margin" resp="author"><quote>« Ut profanos ritus jam salubri lege
-                  submovimus ; ita festos conventus civium, et communem omnium lætitiam non patimur
-                  submoveri. Unde absque ullo sacrificio, atque ulla superstitione damnabili
-                  exhibere populo voluptates secundum veterem consuetudinem ; inire etiam festa
-                  convivia, si quando exigunt publica vota, decernimus. »</quote> Cod. de Paganis,
-                et sacrif.</note>
-              <quote>. <quote>« Encore que nous ayons aboli les cérémonies profanes ; nous ne
-                  voulons pas néanmoins détruire la joie de nos sujets, dans les assemblées qu’ils
-                  font aux jours de fêtes. Nous ordonnons que ces plaisirs du peuple soient célébrés
-                  selon les anciennes coutumes, et même avec les festins, quand les occasions s’en
-                  présenteront ; mais nous défendons d’y faire aucun sacrifice aux Idoles, ni d’y
-                  pratiquer aucune superstition impie. »  »</quote> </quote>
+                avec les Tragédies et les Comédies <note place="margin" resp="author">Claudian. lib.
+                  2. in Eutrop. Hi tragicos meminere.</note>  ; ce que le Proconsul Manlius
+                Théodorus fit encore sous leur règne dans l’an de sa Magistrature. Aussi quand
+                Arcadius, Honorius, Théodosius voulurent régler les Jeux et les Spectacles publics,
+                qu’ils nommèrent les délices et la joie du peuple, ils n’en défendirent pas
+                absolument la célébration ; mais ils en retranchèrent tous les sacrifices et toutes
+                les superstitions du Paganisme ; et voici comme ils en écrivirent au Proconsul
+                d’Afrique Apollodorus <note place="margin" resp="author"><quote>« Ut profanos ritus
+                    jam salubri lege submovimus ; ita festos conventus civium, et communem omnium
+                    lætitiam non patimur submoveri. Unde absque ullo sacrificio, atque ulla
+                    superstitione damnabili exhibere populo voluptates secundum veterem
+                    consuetudinem ; inire etiam festa convivia, si quando exigunt publica vota,
+                    decernimus. »</quote> Cod. de Paganis, et sacrif.</note>« Encore que nous ayons
+                aboli les cérémonies profanes ; nous ne voulons pas néanmoins détruire la joie de
+                nos sujets, dans les assemblées qu’ils font aux jours de fêtes. Nous ordonnons que
+                ces plaisirs du peuple soient célébrés selon les anciennes coutumes, et même avec
+                les festins, quand les occasions s’en présenteront ; mais nous défendons d’y faire
+                aucun sacrifice aux Idoles, ni d’y pratiquer aucune superstition impie. »</quote> 
             </p>
           </div>
           <div>
@@ -5538,7 +5531,7 @@
               Cardinal Baronius allègue sous le consulat de ce <pb n="91" xml:id="p91"/>Manlius
               Théodorus, l’an 399. <quote>« On me dira<seg type="exquote">, dit Saint
                     Chrysostome<note place="margin" resp="author">
-                    <p><quote>«  Et quid hic, inquiunt, adeo magni sceleris commissum est, ut ab
+                    <quote><p>« Et quid hic, inquiunt, adeo magni sceleris commissum est, ut ab
                         istis sacris cancellis arcendi sint ? Immo quod delictum hoc gravius quæris
                         istorum, qui cum seipsos plane adulterio contaminarint, impudenter, ac
                         rabientium more canum ad sacram mensam irruunt. Quod si avetis adulterii
@@ -5552,10 +5545,9 @@
                         totum ibi desidentes diem, in facies abjectarum fœminarum illarum defixos
                         habent oculos, qua fronte poterunt dicere, quod eas non viderint ad
                         concupiscendum ? ubi verba quoque accedunt fracta, lascivaque, ubi cantiones
-                        meretriciæ, ubi voces vehementer ad voluptatem incitant, et
-                      c……..</quote></p>
-                    <p><quote>« Etenim si hic ubi Psalmi, ubi divinorum eloquiorum enarratio, ubi
-                        Dei metus, multaque reverentia, frequenter ceu latro quispiam versutus, clam
+                        meretriciæ, ubi voces vehementer ad voluptatem incitant, et c……..</p>
+                      <p>Etenim si hic ubi Psalmi, ubi divinorum eloquiorum enarratio, ubi Dei
+                        metus, multaque reverentia, frequenter ceu latro quispiam versutus, clam
                         obrepit concupiscentia, quomodo qui desident in Theatro, qui nihil sani
                         neque audiunt, neque vident ; sed multa diffluunt turpitudine, multa
                         nequitia, qui undique obsidionem patiuntur per aures, per oculos, possint
@@ -5566,24 +5558,25 @@
                         hortor, rogoque, ut prius confessione ac pœnitentia, aliisque remediis
                         omnibus se se a peccato ex Theatricis spectaculis contracto perpurgent,
                         atque ita divinos audiant sermones : neque enim hic a nobis mediocriter
-                        delinquitur…….</quote></p>
-                    <p><quote>« Non metuis, ô homo, non expavescis dum oculis quibus illic lectum
-                        qui est in Orchestra, spectas, ubi detestandæ adulterii fabulæ peraguntur,
-                        iisdem hanc sacram mensam intueris ubi tremenda peraguntur mysteria ? dum
-                        iisdem auribus audis et scortum obscœna loquens, et Prophetam ad arcana
-                        scripturæ introducentem ? Dum eodem corde et lethali sumis venena, et hanc
-                        hostiam sanctam, ac tremendam ? An non hæc sunt viræ subversio, conjugiorum
-                        corruptelæ, bella, pugnæque, et rixæ in domibus ?......</quote></p>
-                    <p><quote>« Quapropter rogo vos omnes ut et ipsi pravas in spectaculis
-                        commorationes vitetis, et alios ab his deductos retrahatis. quid. quid enim
-                        illic geritur, non est oblectatio, sed pernicies, sed pœna, sed supplicium.
-                        Quid prodest illa temporaria voluptas, dum hinc perpetuus nascitur dolor,
-                        dumque nocte pariter ac die a concupiscentia stimularis ?.......</quote></p>
-                    <p><quote>« Excute igitur teipsum, reputans qualis, fias ab Ecclesia rediens ;
-                        rursus qualis a spectaculis ; atque hos dies cum illis conferas, id si
-                        feceris nihil opus est meo sermone ; satis enim fuerit hunc diem cum illo
+                        delinquitur…….</p>
+                      <p>Non metuis, ô homo, non expavescis dum oculis quibus illic lectum qui est
+                        in Orchestra, spectas, ubi detestandæ adulterii fabulæ peraguntur, iisdem
+                        hanc sacram mensam intueris ubi tremenda peraguntur mysteria ? dum iisdem
+                        auribus audis et scortum obscœna loquens, et Prophetam ad arcana scripturæ
+                        introducentem ? Dum eodem corde et lethali sumis venena, et hanc hostiam
+                        sanctam, ac tremendam ? An non hæc sunt viræ subversio, conjugiorum
+                        corruptelæ, bella, pugnæque, et rixæ in domibus ?......</p>
+                      <p>Quapropter rogo vos omnes ut et ipsi pravas in spectaculis commorationes
+                        vitetis, et alios ab his deductos retrahatis. quid. quid enim illic geritur,
+                        non est oblectatio, sed pernicies, sed pœna, sed supplicium. Quid prodest
+                        illa temporaria voluptas, dum hinc perpetuus nascitur dolor, dumque nocte
+                        pariter ac die a concupiscentia stimularis ?.......</p>
+                      <p>Excute igitur teipsum, reputans qualis, fias ab Ecclesia rediens ; rursus
+                        qualis a spectaculis ; atque hos dies cum illis conferas, id si feceris
+                        nihil opus est meo sermone ; satis enim fuerit hunc diem cum illo
                         comparasse, ad ostendendum et quam magna sit hinc utilitas et quam a sit
-                        illinc noxa. »</quote> S. Chrysost. hom. 3. de Davide et Saule.</p>
+                        illinc noxa. »</p></quote>
+                    <p>S. Chrysost. hom. 3. de Davide et Saule.</p>
                   </note>,</seg> le péché que ceux qui sont allés aux Spectacles, ont commis, est-il
                 si grand, qu’il mérite qu’on leur interdise l’entrée de ces lieux sacrés ? Mais y
                 a-t-il de crime si énorme que le leur ? Ils se sont souillés de crime d’adultère ;
@@ -5592,7 +5585,7 @@
                 vous déclarerai point par mes discours, mais par les propres paroles de celui qui
                 doit juger de toutes les actions des hommes : <quote>« Celui <seg type="exquote">,
                     dit-il, </seg> qui verra une femme pour la désirer, a déjà commis l’adultère
-                  dans son cœur</quote>.” Si une femme négligemment parée qui passe par hasard dans
+                  dans son cœur »</quote>. Si une femme négligemment parée qui passe par hasard dans
                 la place publique, blesse souvent par la seule vue de son visage, celui qui la
                 regarde avec trop de curiosité ; ceux qui vont aux Spectacles non par hasard, mais
                 de propre liberté et avec tant d’ardeur, qu’ils abandonnent l’Eglise par un mépris
@@ -5612,7 +5605,7 @@
                 ces personnes de se purifier par la confession, par la pénitence, et par tous les
                 autres remèdes salutaires, des péchés qu’ils ont contractés aux Spectacles du
                 Théâtre, afin qu’ils puissent être admis à entendre <pb n="92" xml:id="p92"/>la
-                parole de Dieu : car ces péchés ne sont point médiocres ?...</quote></p>
+                parole de Dieu : car ces péchés ne sont point médiocres ?... »</quote></p>
             <p>
               <quote>« Ne craignez-vous point, ô hommes ? n’avez-vous point horreur de regarder
                 cette sainte Table, où l’on célèbre les redoutables mystères, des mêmes yeux dont
@@ -5623,13 +5616,13 @@
                 N’appréhendez-vous point de recevoir dans un même cœur un poison mortel, et cette
                 Hostie sainte et terrible ? N’est-ce pas de là que naissent les dérèglements de la
                 vie, les désordres des mariages, les guerres, les troubles et les querelles
-                domestiques ?...</quote>
+                domestiques ?... »</quote>
             </p>
             <p>
               <quote>« C’est pourquoi je vous prie tous de ne point assister à ces infâmes
                 représentations des Spectacles, et d’en retirer les autres ; car tout ce qui s’y
                 fait, bien loin d’être un divertissement, n’est qu’un dérèglement pernicieux, qui
-                n’attire que des peines et des supplices...</quote>
+                n’attire que des peines et des supplices... »</quote>
             </p>
             <p>
               <quote>« Que sert à l’homme de jouir d’un plaisir passager, s’il est suivi d’une
@@ -5681,7 +5674,7 @@
                         dico diem illum formidabilem ? Interim de hujus vitæ rebus sermonem
                         instituamus. Quo pacto, quæso, poterunt qui satanico illi spectaculo
                         intersunt, huc confidenter venire, cum se ab insurgente, ac vehementer
-                        reclamare conscientia sua sentiant condemnari ?</quote></p><p><quote>« An
+                        reclamare conscientia sua sentiant condemnari ? »</quote></p><p><quote>« An
                         non audiunt isti Beatum Paulum Doctorem orbis terrarum dicentem : Quæ
                         societas luci, ad tenebras ? aut quæ pars fideli cum infideli ? 2. Cor. 6.
                         v.15. Quanta enim condemnatione dignum censendum est, cum fidelis qui precum
@@ -5789,12 +5782,12 @@
                         insectandi mundi hujus illecebras cunctas cum potissimum turpia illa populo
                         solita exhiberi spectacula ; vimque addidere dicendi facundiæ anni hujus
                         minæ cælestes, nimirum cum lingua ignea mala portendere cœlum visum est,
-                        juxta illud Lucani lib. 1.<lb/> “Terris minitantem regna Cometen.” </quote>
+                        juxta illud Lucani lib. 1.<lb/> “Terris minitantem regna Cometen. »</quote>
                     </p>
                     <p><quote>« De quo Socrates lib. 6. <quote>« Tam grave, inquit, etiam imminebat
                           periculum civitati, ut Cometa maximus a cœlo, ad terram usque pervadens
                           (similem vero ante nemo unquam aspexerat) illud ipsum portenderet…….
-                           »</quote></quote></p>
+                           »</quote> »</quote></p>
                     <p><quote>« Eademque de admirando prodigio Sozomenus habet l.8.c.4. “Hic
                         accessit ingens siccitas ut cœlum æreum esse redditum videretur.” His,
                         inquam omnibus rerum accidentibus Chrysostomus bene usus validius adversus
@@ -5828,7 +5821,7 @@
                   hommes jusqu’à quand aurez-vous le cœur appesanti ? jusqu’à quand aimerez-vous la
                   vanité dans les Spectacles ? jusqu’à quand chercherez-vous le mensonge parmi les
                   Comédiens, et les Farceurs ? Sachez que Dieu a séparé pour lui-même toute âme qui
-                  ne s’éloigne point de l’Eglise. »  »</quote></quote></p>
+                  ne s’éloigne point de l’Eglise. »</quote> »</quote></p>
             <p><quote>« Que gagna enfin ce saint Prélat par ses prédications continuelles, à temps
                 et à contretemps ? »</quote> Il obtint une chose très importante ; savoir que le
               spectacle infâme de Majuma fut entièrement aboli, par la loi que l’Empereur Arcade
@@ -5883,56 +5876,56 @@
               clairement combien les Spectacles étaient souillés d’impureté, et de superstition sous
               le règne d’Arcadius, et d’Honorius, qu’il n’y a que le seul Auteur de la Dissertation
               qui l’ait pu ignorer ; C’est toutefois ce qu’il pouvait encore aisément apprendre par
-              la lecture des mêmes Annales de Baronius. <quote>« L’an 404<seg type="exquote">. dit
-                  ce Cardinal<note place="margin" resp="author"><p><quote>« Quadrigentesimus quartus
-                        sequitur Christi annus, titulo consulatus VI. Honorii Imperatoris, et
-                        Aristeneti publicis fastis adscriptus : quo pariter sæculares ludi a
-                        superstitione introducti Gentilium, Constantini vero religione neglecti,
-                        atque penitus prætermissi, non sine dedecore Christiani nominis editi sunt….
-                        Male persuasus Honorius, quod hos fatales esse perpetuitatis Urbis, et
-                        fœlicis ejus status conciliatores Gentiles dicerent, eorumdem consilio et
-                        suasione inductus et seductus est, ut quos despexerat Constantinus ille
-                        magnus, ipse imprudens restitueret ; Accidisse enim videtur, ut recentis
-                        adversus Alaricum apud Pollentiam obtentæ victoriæ, et decreti sibi a Senatu
-                        triumphi elatus gloria, quid peteretur, quid ve concesserit, minime
-                        cogitarit. Gentiles itaque quod in his putarent Urbis æternitatem faustis
-                        auspiciis consecrari, qui nuper timore descendemis in Italiam Alarici
-                        perterrofacti, novis cinxerant Urbem mœniis, eam patria quoque putarunt
-                        religione fore muniendam : cum perinde ac Zozimus lib. 2. licentius
-                        effutirent, ob neglectos superioris sæculi ludos in hæc mala incidisse, ut a
-                        Barbaris devastaretur Romanorum imperium, et ipsa Roma in discrimine posita
-                        esset : quibus inductus Honorius eisdem summa imperii jactura assensum
-                        præbuit, nam eo scelere ad excidium Urbis Deum sollicitavit. Cum alioqui
-                        satis experimento esse debuisse omnia hæc inaniter fieri, quod sub
-                        Constantino, qui eos prætermisit ludos, Romanum imperium, extinctis
-                        Tyrannis, et debellatis Barbaris, omni ex parte florentissimum visum est.
-                        Sed damno suo atque jactura ipsius Urbis, cujus æternitati male
-                        superstitione consulebatur, expertus est quantum ex perperam facto justam
-                        Dei vindictam commoverit, qui paucos post annos eam quam prævio Christi
-                        nomine liberaverat, iisdem Gothis, eodem Alarico duce dederit capiendam
-                        atque prædandam.</quote></p><p><quote>« Scimus Honorium excusari quod etsi
-                        Romanis Gentilibus concessit sæculares celebrari ludos ; voluisse tamen haud
-                        ritibus illis Gentilitiis ipsos agi : sed indulsisse tantum ut Theatrales
-                        atque Circenses ludi exhiberentur. At quæ sine superstitione spectacula ?
-                        aut quis putat occini prætermissa a pueris et puellis sybillina illa carmina
-                        in his edendis ludis solennia ? Certe quidem revocata tot Chrstianorum
-                        Imperatorum legibus vetita Gladiatorum munera, his temporibus sub Honorio
-                        rursum exhibita locuples testis est Prudentius lib. 2. adversus Symmachum,
-                        qui post decantatam Pollentinam victoriam haud pridem Christi virtute
-                        partam, ad finem hortatur Honorium ut Gladiatorium penitus ludos vetet :
-                        <lb/>“Tu mortes miserorum hominum prohibeto litari.<lb/> Nullus in urbe
-                        cadat, cujus sit pœna voluptas. »</quote>
-                    </p>
-                    <p><quote>« Grande sane piaculum, ut quæ tot legibus Christianorum Principum
-                        prohibita erant cruenta Gladiatorum spectacula, et quæ, ut vidimus, ne
-                        fierent redempta fuerant sanguine Martyriis (Thelemachi) essent iterum
-                        restituta ab ipsis Gentilibus, et quidem solenni ritu, ad quæ spectacula
-                        prodirent, ut Prudentius ait, cum pompa Vestales virgines. Quæ facinora
-                        digna Dei vindicta Romano sanguine per Gothorum gladium Deus voluit
-                        expiari. »</quote> Baron. ad ann. 404.</p></note>,</seg> il y eut pour
-                Consul l’Empereur Honorius, et Aristenet, et en cette même année les jeux séculaires
-                introduits par la superstition des Païens, que la piété de Constantin avait
-                négligés, et tout à fait rejetés, furent célébrés à la honte du Christianisme.
+              la lecture des mêmes Annales de Baronius. </p>
+            <quote>
+              <p>« L’an 404<seg type="exquote">. dit ce Cardinal <note place="margin" resp="author"
+                        ><quote><p>« Quadrigentesimus quartus sequitur Christi annus, titulo
+                        consulatus VI. Honorii Imperatoris, et Aristeneti publicis fastis
+                        adscriptus : quo pariter sæculares ludi a superstitione introducti
+                        Gentilium, Constantini vero religione neglecti, atque penitus prætermissi,
+                        non sine dedecore Christiani nominis editi sunt…. Male persuasus Honorius,
+                        quod hos fatales esse perpetuitatis Urbis, et fœlicis ejus status
+                        conciliatores Gentiles dicerent, eorumdem consilio et suasione inductus et
+                        seductus est, ut quos despexerat Constantinus ille magnus, ipse imprudens
+                        restitueret ; Accidisse enim videtur, ut recentis adversus Alaricum apud
+                        Pollentiam obtentæ victoriæ, et decreti sibi a Senatu triumphi elatus
+                        gloria, quid peteretur, quid ve concesserit, minime cogitarit. Gentiles
+                        itaque quod in his putarent Urbis æternitatem faustis auspiciis consecrari,
+                        qui nuper timore descendemis in Italiam Alarici perterrofacti, novis
+                        cinxerant Urbem mœniis, eam patria quoque putarunt religione fore
+                        muniendam : cum perinde ac Zozimus lib. 2. licentius effutirent, ob
+                        neglectos superioris sæculi ludos in hæc mala incidisse, ut a Barbaris
+                        devastaretur Romanorum imperium, et ipsa Roma in discrimine posita esset :
+                        quibus inductus Honorius eisdem summa imperii jactura assensum præbuit, nam
+                        eo scelere ad excidium Urbis Deum sollicitavit. Cum alioqui satis
+                        experimento esse debuisse omnia hæc inaniter fieri, quod sub Constantino,
+                        qui eos prætermisit ludos, Romanum imperium, extinctis Tyrannis, et
+                        debellatis Barbaris, omni ex parte florentissimum visum est. Sed damno suo
+                        atque jactura ipsius Urbis, cujus æternitati male superstitione
+                        consulebatur, expertus est quantum ex perperam facto justam Dei vindictam
+                        commoverit, qui paucos post annos eam quam prævio Christi nomine
+                        liberaverat, iisdem Gothis, eodem Alarico duce dederit capiendam atque
+                        prædandam.</p><p>Scimus Honorium excusari quod etsi Romanis Gentilibus
+                        concessit sæculares celebrari ludos ; voluisse tamen haud ritibus illis
+                        Gentilitiis ipsos agi : sed indulsisse tantum ut Theatrales atque Circenses
+                        ludi exhiberentur. At quæ sine superstitione spectacula ? aut quis putat
+                        occini prætermissa a pueris et puellis sybillina illa carmina in his edendis
+                        ludis solennia ? Certe quidem revocata tot Chrstianorum Imperatorum legibus
+                        vetita Gladiatorum munera, his temporibus sub Honorio rursum exhibita
+                        locuples testis est Prudentius lib. 2. adversus Symmachum, qui post
+                        decantatam Pollentinam victoriam haud pridem Christi virtute partam, ad
+                        finem hortatur Honorium ut Gladiatorium penitus ludos vetet : <lb/>« Tu
+                        mortes miserorum hominum prohibeto litari.<lb/> Nullus in urbe cadat, cujus
+                        sit pœna voluptas. »</p><p>Grande sane piaculum, ut quæ tot legibus
+                        Christianorum Principum prohibita erant cruenta Gladiatorum spectacula, et
+                        quæ, ut vidimus, ne fierent redempta fuerant sanguine Martyriis (Thelemachi)
+                        essent iterum restituta ab ipsis Gentilibus, et quidem solenni ritu, ad quæ
+                        spectacula prodirent, ut Prudentius ait, cum pompa Vestales virgines. Quæ
+                        facinora digna Dei vindicta Romano sanguine per Gothorum gladium Deus voluit
+                        expiari. »</p></quote><p> Baron. ad ann. 404.</p></note> ,</seg> il y eut
+                pour Consul l’Empereur Honorius, et Aristenet, et en cette même année les jeux
+                séculaires introduits par la superstition des Païens, que la piété de Constantin
+                avait négligés, et tout à fait rejetés, furent célébrés à la honte du Christianisme.
                 Honorius étant mal conseillé par les Gentils qui étaient de son conseil, et qui
                 disaient que la destinée de la perpétuité de la ville de Rome, et de la félicité de
                 l’Etat, était attachée à ces jeux, se laissa séduire par leur conseil, et par leur
@@ -5958,9 +5951,8 @@
                 on employait si mal la superstition, lui fit ressentir combien en commettant ce
                 crime il avait excité la vengeance de Dieu ; car en effet peu d’années après Dieu
                 permit que les Goths sous la conduite d’Alaric, prissent et pillassent cette ville,
-                qu’il avait auparavant délivrée par la protection du nom de
-              Jésus-Christ.</quote></p>
-            <p><quote>« Nous savons bien que quelques-uns tâchent d’excuser Honorius, sous prétexte
+                qu’il avait auparavant délivrée par la protection du nom de Jésus-Christ.</p>
+              <p>Nous savons bien que quelques-uns tâchent d’excuser Honorius, sous prétexte
                 qu’encore qu’il eût permis aux Païens de Rome de célébrer les Jeux Séculaires, il
                 n’avait pas voulu néanmoins qu’ils fussent célébrés avec les cérémonies Païennes ;
                 leur permettant seulement de représenter les Jeux du Théâtre, et du Cirque. Mais y
@@ -5974,15 +5966,15 @@
                 fin Honorius d’interdire entièrement les Jeux des Gladiateurs : <quote>« Ne
                   permettez point<seg type="exquote">, dit-il, </seg>les victimes sanglantes de ces
                   misérables qu’on égorge ; Ne souffrez point que dans la ville on fasse un
-                  divertissement du supplice et de la mort de personne. »</quote></quote></p>
-            <p><quote>« En vérité ce fut un grand péché de permettre que ces cruels Spectacles des
+                  divertissement du supplice et de la mort de personne. »</quote></p>
+              <p>En vérité ce fut un grand péché de permettre que ces cruels Spectacles des
                 Gladiateurs, que tant de lois des Empereurs Chrétiens avaient défendus, et pour
                 l’abolition desquels ce généreux Martyr Télémaque avait répandu son sang, fussent
                 rétablis de nouveau par les Païens avec des cérémonies solennelles ; puisque, comme
                 dit Prudence, les Vestales allèrent avec pompe à ces Spectacles. Ces<pb n="100"
                   xml:id="p100"/>crimes attirèrent la vengeance de Dieu, de sorte qu’il se servit de
-                l’épée des Goths pour les expier par l’effusion du sang des Romains. »</quote> On
-              vit les effets de cette vengeance de Dieu six ans après ; car Rome fut prise et
+                l’épée des Goths pour les expier par l’effusion du sang des Romains. »</p></quote>
+            <p> On vit les effets de cette vengeance de Dieu six ans après ; car Rome fut prise et
               saccagée par Alaric l’an 410. sous le règne d’Honorius, et du jeune Théodose. Mais ce
               qui est étrange, c’est que cette horrible désolation n’eut pas la force d’éteindre la
               passion que le peuple Romain avait pour les Spectacles ; car Alaric ne fut pas plutôt
@@ -6009,19 +6001,18 @@
                   audietur) Romana Urbe vastata, quos pestilentia ista possedit, atque inde
                   fugientes, Carthaginem pervenire potuerunt in Theatris quotidie certatim pro
                   Histrionibus insanirent. »</quote> S. August. l.1 <hi rend="i">de Civit. Dei</hi>.
-                cap. 32.</note>. <quote>« Les malins esprits qui sont si rusés, et si artificieux,
-                s’appliquèrent à répandre non dans les corps, mais dans les mœurs  des hommes, la
-                peste des jeux de la Scène, qui est beaucoup plus dangereuse que celle qui afflige
-                les corps : Elle offusqua tellement leur raison, et la défigura d’une manière si
-                honteuse, que maintenant même dans la désolation de Rome, ce que la postérité aura
-                peine à croire, ceux qui ont été infectés d’une si mortelle peste, et qui fuyant le
-                désastre de leur patrie, ont pu se retirer à Carthage, courent encore tous les jours
-                au Théâtre, où à l’envi les uns des autres, par la passion qu’ils ont pour les
-                Comédiens et pour les Farceurs, ils montrent l’extrême folie qu’ils ont dans
-                l’esprit.</quote></p>
-            <p>
-              <quote>« O esprits insensés <note place="margin" resp="author"><p>
-                    <quote>« O mentes amentes, quis est hic tantus non error, sed furor, ut exitium
+                cap. 32.</note>.</p>
+            <quote><p>« Les malins esprits qui sont si rusés, et si artificieux, s’appliquèrent à
+                répandre non dans les corps, mais dans les mœurs  des hommes, la peste des jeux de
+                la Scène, qui est beaucoup plus dangereuse que celle qui afflige les corps : Elle
+                offusqua tellement leur raison, et la défigura d’une manière si honteuse, que
+                maintenant même dans la désolation de Rome, ce que la postérité aura peine à croire,
+                ceux qui ont été infectés d’une si mortelle peste, et qui fuyant le désastre de leur
+                patrie, ont pu se retirer à Carthage, courent encore tous les jours au Théâtre, où à
+                l’envi les uns des autres, par la passion qu’ils ont pour les Comédiens et pour les
+                Farceurs, ils montrent l’extrême folie qu’ils ont dans l’esprit.</p><p> O esprits
+                insensés <note place="margin" resp="author">
+                  <quote><p>« O mentes amentes, quis est hic tantus non error, sed furor, ut exitium
                       vestrum, sicut audivimus plangentibus Orientalibus populis, et maximis
                       civitatibus in remotissimis terris publicum luctum, mœroremque ducentibus, vos
                       Theatra quæreretis, intraretis, impleretis, et multo insaniora quam fuerant
@@ -6034,14 +6025,13 @@
                       providi præcaverunt. Hinc est quod male quæ facitis, vobis imputari non
                       vultis ; mala vero quæ patimini, Christianis temporibus imputatis. Neque enim
                       in vestra securitate pacatam rempublicam, sed luxuriam quæritis impunitam, qui
-                      depravati rebus prosperis, nec corrigi potuistis ad
-                      versis.</quote></p><p><quote>«  Volebat vos ille Scipio terreri ab hoste, ne
-                      in luxuriam flueretis. Vos nec contriti ab hoste luxuriam repressistis.
-                      Perdidistis utilitatem calamitatis, et miserrimi facti estis ; et pessimi
-                      permansistis, et tamen quod vivitis, Dei est qui vobis parcendo admonet, ut
-                      corrigamini pœnitando, qui vobis etiam ingratis præstitit, ut vel sub nomine
-                      servorum ejus, vel in locis Martyrum ejus hostiles manus evaderetis.</quote>
-                     » Ibid. cap. 33.</p>
+                      depravati rebus prosperis, nec corrigi potuistis ad versis.</p><p>Volebat vos
+                      ille Scipio terreri ab hoste, ne in luxuriam flueretis. Vos nec contriti ab
+                      hoste luxuriam repressistis. Perdidistis utilitatem calamitatis, et miserrimi
+                      facti estis ; et pessimi permansistis, et tamen quod vivitis, Dei est qui
+                      vobis parcendo admonet, ut corrigamini pœnitando, qui vobis etiam ingratis
+                      præstitit, ut vel sub nomine servorum ejus, vel in locis Martyrum ejus
+                      hostiles manus evaderetis.  »</p></quote><p> Ibid. cap. 33.</p>
                 </note> , quelle est, je ne dirai pas cette erreur qui vous aveugle, mais cette
                 fureur qui vous transporte <pb n="101" xml:id="p101"/> et qui fait que lorsque tous
                 les peuples d’Orient, que les plus grandes et les plus célèbres villes des lieux
@@ -6070,8 +6060,7 @@
                 vous corriger, et de faire pénitence, et qui vous a fait cette faveur, que vous
                 reconnaissez si mal par votre ingratitude, que sous le nom de ses serviteurs, ou
                 dans les lieux consacrés en l’honneur de ses Martyrs, vous avez échappé des mains de
-                vos ennemis. »</quote>
-            </p>
+                vos ennemis. »</p></quote>
             <p><pb n="102" xml:id="p102"/>Ce que je viens de rapporter, fait voit clairement combien
               les Spectacles étaient indignes des Chrétiens, et combien ils étaient souillés de
               superstition sous le règne d’Arcadius, et d’Honorius ; combien encore était grande la
@@ -6101,9 +6090,7 @@
                 bien. Les jeux de la Scène, ces spectacles où l’on ne voit que des infamies, et des
                 ordures, que des images de vanité, et de licence, ont été institués à Rome non par
                 le vice, et la corruption des hommes ; mais par le commandement de vos
-                Dieux.</quote></p>
-            <p>
-              <quote>« Peut-être que Scipion me répondrait s’il était vivant : comment ne
+                Dieux. Peut-être que Scipion me répondrait s’il était vivant : comment ne
                 jugerions-nous pas ces choses licites, puisque les Dieux les ont voulu consacrer,
                 lorsqu’ils ont introduit dans les mœurs des Romains les jeux de la Scène, où l’on
                 célèbre, où l’on prononce, où l’on représente ces impuretés, et qu’ils ont commandé
@@ -6167,9 +6154,9 @@
               l’Eglise, ils ne leur sont licites en aucun temps.</p>
             <p>C’est ce que nous allons faire voir plus au long sur chacune de ces lois. La première
               fut faite l’an 386. en ces termes<note place="margin" resp="author">
-                <p><quote>« Ne quis in legem nostram quam dudum tulimus, committat.</quote></p>
-                <p><quote>« Nullus solis die populo spectaculum præbeat, nec divinam venerationem
-                    confecta solennitate confundat. »</quote> L. 2. cod. Theodos.</p>
+                <quote><l>« Ne quis in legem nostram quam dudum tulimus, committat.</l>
+                  <l>Nullus solis die populo spectaculum præbeat, nec divinam venerationem confecta
+                    solennitate confundat. »</l></quote><p> L. 2. cod. Theodos.</p>
               </note> : <quote>« Que nul ne transgresse la loi que nous avons faite il y a
                 longtemps : Que nul ne donne des Spectacles au peuple le jour du Dimanche, en
                 causant de la confusion et du désordre dans la célébration et la solennité du
@@ -6185,116 +6172,95 @@
               étaient pernicieux en eux-mêmes, dans leurs circonstances, et dans leurs effets ;
               combien ils étaient indignes des Chrétiens ; et combien le péché qu’ils commettaient
               en y allant, même les jours ouvriers, était grand devant Dieu.</p>
-            <p>
-              <quote>« Ce n’est point à nous<seg type="exquote">, dit-il <note place="margin"
-                    resp="author"><p>
-                      <quote>« Non est nostrum assidue ridere, resolvi cachinnis, et molliri
+
+            <quote><p>« Ce n’est point à nous<seg type="exquote">, dit-il <note place="margin"
+                    resp="author">
+                    <quote><p>« Non est nostrum assidue ridere, resolvi cachinnis, et molliri
                         deliciis…..Non est hoc, inquam, eorum qui ad æternum regnum vocati sunt,
                         quique sunt in illa cœlesti civitate, conscripti : non est spiritualia arma
-                        gestantium ; sed diabolo militantium.</quote></p><p><quote>« Ille est enim
-                        ille qui etiam in artem, jocos ludosque digessit, ut per hæc ad se traheret
-                        milites Christi, virtutisque eorum nervos faceret molliores. Propterea in
-                        urbibus etiam Theatra construxit, et illos risuum incensores paravit, ut per
-                        illorum luem, in universam urbem talem exciter pestem.</quote></p>
-                    <p><quote>« Quæ nos fugere præcepit Paulus suadens ut et stultitiam et
-                        scurrilitatem a nobis longius repellamus, ex quibus risus multo perniciosior
-                        est, multoque deterior.</quote></p><p><quote>« Quando enim mimi illi, atque
-                        ridiculi blasphemum, ac turpe quid dixerunt, tunc potissimum quique
-                        stolidiores solvuntur in risum ; inde applaudentes magis, unde etiam illos
-                        lapidibus exagitare debuerant ; ac fornacem ignis horibilis ex hujusmodi
-                        voluptate in suum ipsorum caput succendentes. Qui enim laudant illa
-                        dicentes, ipsi eis hæc exercere persuadent ; et idcirco ipsi potius propter
-                        hæc merentur subire quod ob ista sancitum est supplicium. Si enim nullus
-                        esset talium spectator ac fautor, nec essent quidem qui aut dicere illa, aut
-                        agere curarent. Quando vero vos cernunt, et artes proprias, et ipsa
-                        exercendi quotidiani operis loca, et illum quem ex his paratis quæstum, et
-                        prorsus omnia simul vanissimi illius spectaculi amore deserere, avidiori et
-                        illi ad hæc intentione rapiuntur, studiumque his majus
-                      impendiunt.</quote></p><p><quote>« Et hæc dico, non ut illos a crimine
-                        vindicem ; sed ut vos discatis initium et caput hujus iniquitatis vos esse
-                        potissimum, qui totam prorsus diem in tam ridicula, tamque etiam perniciosa
-                        voluptate consumitis, et honestum conjugii nomen ac reverendum in illud
-                        negotium publicatis. Non enim tam ille delinquit qui illa simulatquam tu præ
-                        illo, qui hoc fieri jubes ; nec solum jubes ; sed etiam exultatione, risu,
-                        plausu adjuvas quæ geruntur, omnibusque prorsus modis hanc diabolicam
-                        confoves officinam.</quote></p><p><quote>« Neque vero illud mihi opponas,
-                        quod jam quidquid ibi sit, simulatio et fictum argumentum sit, non etiam
-                        veritas rerum. Etenim simulatio illa plurimos adulteros fecit, et multas
-                        domos subvertit. Proptereaque maxime gemo, quod tam grande malum hoc, malum
-                        esse, non creditur. Sed quod est multo deterrimum, et favor, et clamor, et
-                        plausus adhibetur, et risus, cum in comune perniciem adulterium tam turpe
-                        committitur.</quote></p><p><quote>« Quid ergo ais, simulatio est illa, non
-                        crimen ? et propterea mille illi mortibus digni sunt, quoniam quæ fugere
-                        cunctæ prorsus imperant leges, ea isti non verentur imitari. Si enim
-                        adulterium malum est ; malum sine dubio est illius imitatio, et nondum dico
-                        quantos adulteros faciant, qui hujusmodi adulteria histrionica simulatione
-                        repræsentant quemadmodum etiam impudentes horum spectatores efficiant. Nihil
-                        quippe obscenius illo oculo, nihilque lascivius, qui spectare talia
-                        patienter potest.  »</quote> S. Chrysost. hom. 6. in cap. 2
-                    Matth.</p></note>,</seg> à passer le temps dans les ris, dans les
-                divertissements, et dans les délices.…Ce n’est point là l’esprit de ceux qui sont
-                appelés à une vie céleste, dont les noms sont déjà écrits dans cette éternelle cité,
-                et qui font profession d’une milice toute spirituelle ; mais c’est l’esprit de ceux
-                qui combattent sous les enseignes du démon.</quote>
-            </p>
-            <p>
-              <quote>« Oui, mes frères, c’est le démon qui a fait un art de ces divertissements, et
-                de ces jeux, pour attirer à lui les soldats de Jésus-Christ, et pour relâcher toute
-                la vigueur, et comme les nerfs de leur vertu. C’est pour ce sujet qu’il a fait
-                dresser des Théâtres dans les places publiques, et qu’exerçant et formant lui-même
-                ces bouffons, il s’en sert comme d’une peste, dont il infecte toute la
-                ville.</quote>
-            </p>
-            <p>
-              <quote>« Saint Paul nous a défendu les paroles impertinentes, et celles qui ne tendent
-                qu’à un vain divertissement ; mais le démon nous persuade d’aimer les unes et les
-                autres.</quote>
-            </p>
-            <p>
-              <quote>« Ce qui est encore plus dangereux, est le sujet pour lequel on s’emporte dans
-                ces ris immodérés. Car aussitôt que ces bouffons ridicules ont proféré quelque
-                blasphème, ou quelque parole déshonnête, on voit que les plus fous sont ravis de
-                joie, et s’emportent dans des éclats de rire ; ils leur applaudissent pour des
-                choses pour lesquelles on les devrait <pb n="106" xml:id="p106"/> lapider ; et ils
-                s’attirent ainsi sur eux-mêmes par ce plaisir malheureux, le supplice d’un feu
-                éternel. Car en les louant·de ces folies, on leur persuade de les faire, on se rend
-                encore plus digne qu’eux de la condamnation qu’ils ont méritée. Si tout le monde
-                s’accordait à ne vouloir point regarder leurs sottises, ils cesseraient bientôt de
-                les faire. Mais lorsqu’ils vous voient tous les jours quitter vos occupations, vos
-                travaux, et l’argent qui vous en revient, en un mot, renoncer à tout pour assister à
-                ces Spectacles, ils redoublent leur ardeur, et ils s’appliquent bien davantage à ces
-                niaiseries. </quote>
-            </p>
-            <p>
-              <quote>« Je ne dis pas ceci pour les excuser, mais pour vous faire voir, que c’est
-                vous principalement qui êtes la source de tous ces dérèglements, en assistant à
-                leurs Jeux, et y passant les journées entières. C’est vous qui dans ces
-                représentations malheureuses profanez la sainteté du mariage, et qui déshonorez
-                devant tout le monde ce grand Sacrement. Car celui qui représente ces personnages
-                infâmes, est moins coupable que vous qui les faites représenter ; que vous qui
-                l’animez de plus en plus par votre passion, par vos ravissements, par vos éclats, et
-                par vos louanges, et qui travaillez en toutes manières à embellir, et à relever cet
-                ouvrage du démon....</quote>
-            </p>
-            <p>
-              <quote>« Ne me dites point que tout ce qui se fait alors n’est qu’une fiction ; cette
-                fiction a fait beaucoup d’adultères véritables, et a renversé beaucoup de familles.
-                C’est ce qui m’afflige davantage, que ce mal étant si grand, on ne le regarde pas
-                même comme un mal, et que lorsqu’on représente un crime aussi grand qu’est celui de
-                l’adultère, on n’entend que des applaudissements et des cris de joie.</quote>
-            </p>
-            <p>
-              <quote>« Ce n’est qu’une feinte, dites-vous ; c’est donc pour cela même que ces
-                personnes sont dignes de mille morts, d’oser exposer aux yeux de tout le monde des
-                désordres qui sont défendus par toutes les lois. Si l’adultère est un mal, c’est un
-                mal aussi de le représenter.</quote>
-            </p>
-            <p>
-              <quote>« Qui pourrait dire combien ces fictions rendent de personnes adultères ; et
-                combien elles inspirent l’impudence, et l’impureté dans tous ceux qui les regardent,
-                car il n’y a <pb n="107" xml:id="p107"/> rien de plus impudique que l’œil qui peut
-                souffrir de voir ces ordures. »</quote>
-            </p>
+                        gestantium ; sed diabolo militantium.</p><p> Ille est enim ille qui etiam in
+                        artem, jocos ludosque digessit, ut per hæc ad se traheret milites Christi,
+                        virtutisque eorum nervos faceret molliores. Propterea in urbibus etiam
+                        Theatra construxit, et illos risuum incensores paravit, ut per illorum luem,
+                        in universam urbem talem exciter pestem.</p><p> Quæ nos fugere præcepit
+                        Paulus suadens ut et stultitiam et scurrilitatem a nobis longius repellamus,
+                        ex quibus risus multo perniciosior est, multoque deterior.</p><p> Quando
+                        enim mimi illi, atque ridiculi blasphemum, ac turpe quid dixerunt, tunc
+                        potissimum quique stolidiores solvuntur in risum ; inde applaudentes magis,
+                        unde etiam illos lapidibus exagitare debuerant ; ac fornacem ignis horibilis
+                        ex hujusmodi voluptate in suum ipsorum caput succendentes. Qui enim laudant
+                        illa dicentes, ipsi eis hæc exercere persuadent ; et idcirco ipsi potius
+                        propter hæc merentur subire quod ob ista sancitum est supplicium. Si enim
+                        nullus esset talium spectator ac fautor, nec essent quidem qui aut dicere
+                        illa, aut agere curarent. Quando vero vos cernunt, et artes proprias, et
+                        ipsa exercendi quotidiani operis loca, et illum quem ex his paratis quæstum,
+                        et prorsus omnia simul vanissimi illius spectaculi amore deserere, avidiori
+                        et illi ad hæc intentione rapiuntur, studiumque his majus
+                        impendiunt.</p><p> Et hæc dico, non ut illos a crimine vindicem ; sed ut vos
+                        discatis initium et caput hujus iniquitatis vos esse potissimum, qui totam
+                        prorsus diem in tam ridicula, tamque etiam perniciosa voluptate consumitis,
+                        et honestum conjugii nomen ac reverendum in illud negotium publicatis. Non
+                        enim tam ille delinquit qui illa simulatquam tu præ illo, qui hoc fieri
+                        jubes ; nec solum jubes ; sed etiam exultatione, risu, plausu adjuvas quæ
+                        geruntur, omnibusque prorsus modis hanc diabolicam confoves
+                        officinam.</p><p> Neque vero illud mihi opponas, quod jam quidquid ibi sit,
+                        simulatio et fictum argumentum sit, non etiam veritas rerum. Etenim
+                        simulatio illa plurimos adulteros fecit, et multas domos subvertit.
+                        Proptereaque maxime gemo, quod tam grande malum hoc, malum esse, non
+                        creditur. Sed quod est multo deterrimum, et favor, et clamor, et plausus
+                        adhibetur, et risus, cum in comune perniciem adulterium tam turpe
+                        committitur.</p><p>Quid ergo ais, simulatio est illa, non crimen ? et
+                        propterea mille illi mortibus digni sunt, quoniam quæ fugere cunctæ prorsus
+                        imperant leges, ea isti non verentur imitari. Si enim adulterium malum est ;
+                        malum sine dubio est illius imitatio, et nondum dico quantos adulteros
+                        faciant, qui hujusmodi adulteria histrionica simulatione repræsentant
+                        quemadmodum etiam impudentes horum spectatores efficiant. Nihil quippe
+                        obscenius illo oculo, nihilque lascivius, qui spectare talia patienter
+                        potest.  »</p></quote><p> S. Chrysost. hom. 6. in cap. 2
+                  Matth.</p></note>,</seg> à passer le temps dans les ris, dans les divertissements,
+                et dans les délices.…Ce n’est point là l’esprit de ceux qui sont appelés à une vie
+                céleste, dont les noms sont déjà écrits dans cette éternelle cité, et qui font
+                profession d’une milice toute spirituelle ; mais c’est l’esprit de ceux qui
+                combattent sous les enseignes du démon.</p><p>Oui, mes frères, c’est le démon qui a
+                fait un art de ces divertissements, et de ces jeux, pour attirer à lui les soldats
+                de Jésus-Christ, et pour relâcher toute la vigueur, et comme les nerfs de leur
+                vertu. C’est pour ce sujet qu’il a fait dresser des Théâtres dans les places
+                publiques, et qu’exerçant et formant lui-même ces bouffons, il s’en sert comme d’une
+                peste, dont il infecte toute la ville.</p><p>Saint Paul nous a défendu les paroles
+                impertinentes, et celles qui ne tendent qu’à un vain divertissement ; mais le démon
+                nous persuade d’aimer les unes et les autres.</p><p>Ce qui est encore plus
+                dangereux, est le sujet pour lequel on s’emporte dans ces ris immodérés. Car
+                aussitôt que ces bouffons ridicules ont proféré quelque blasphème, ou quelque parole
+                déshonnête, on voit que les plus fous sont ravis de joie, et s’emportent dans des
+                éclats de rire ; ils leur applaudissent pour des choses pour lesquelles on les
+                devrait <pb n="106" xml:id="p106"/> lapider ; et ils s’attirent ainsi sur eux-mêmes
+                par ce plaisir malheureux, le supplice d’un feu éternel. Car en les louant·de ces
+                folies, on leur persuade de les faire, on se rend encore plus digne qu’eux de la
+                condamnation qu’ils ont méritée. Si tout le monde s’accordait à ne vouloir point
+                regarder leurs sottises, ils cesseraient bientôt de les faire. Mais lorsqu’ils vous
+                voient tous les jours quitter vos occupations, vos travaux, et l’argent qui vous en
+                revient, en un mot, renoncer à tout pour assister à ces Spectacles, ils redoublent
+                leur ardeur, et ils s’appliquent bien davantage à ces niaiseries.</p><p>Je ne dis
+                pas ceci pour les excuser, mais pour vous faire voir, que c’est vous principalement
+                qui êtes la source de tous ces dérèglements, en assistant à leurs Jeux, et y passant
+                les journées entières. C’est vous qui dans ces représentations malheureuses profanez
+                la sainteté du mariage, et qui déshonorez devant tout le monde ce grand Sacrement.
+                Car celui qui représente ces personnages infâmes, est moins coupable que vous qui
+                les faites représenter ; que vous qui l’animez de plus en plus par votre passion,
+                par vos ravissements, par vos éclats, et par vos louanges, et qui travaillez en
+                toutes manières à embellir, et à relever cet ouvrage du démon....</p><p>Ne me dites
+                point que tout ce qui se fait alors n’est qu’une fiction ; cette fiction a fait
+                beaucoup d’adultères véritables, et a renversé beaucoup de familles. C’est ce qui
+                m’afflige davantage, que ce mal étant si grand, on ne le regarde pas même comme un
+                mal, et que lorsqu’on représente un crime aussi grand qu’est celui de l’adultère, on
+                n’entend que des applaudissements et des cris de joie.</p><p>Ce n’est qu’une feinte,
+                dites-vous ; c’est donc pour cela même que ces personnes sont dignes de mille morts,
+                d’oser exposer aux yeux de tout le monde des désordres qui sont défendus par toutes
+                les lois. Si l’adultère est un mal, c’est un mal aussi de le représenter.</p><p>Qui
+                pourrait dire combien ces fictions rendent de personnes adultères ; et combien elles
+                inspirent l’impudence, et l’impureté dans tous ceux qui les regardent, car il n’y a
+                  <pb n="107" xml:id="p107"/> rien de plus impudique que l’œil qui peut souffrir de
+                voir ces ordures. »</p></quote>
             <p>Vous voyez donc comme lorsque les Empereurs Gratien, Valentinien, et Théodose
               défendaient les Spectacles au jour du Dimanche, saint Chrysostome montrait qu’ils
               étaient défendus aux Chrétiens tous les autres jours ; parce que ce n’est point
@@ -6354,7 +6320,7 @@
                   operam præstat subeundam forsitan sibi nostræ serenitatis offensam, si minus circa
                   nos devotionis ostenderit quam solebat, nemo ambigat quod tunc maxime mansuetudini
                   nostræ ab humano genere defertur, eum virtutibus Dei Omnipotentis, ac meritis
-                  universi obsequium orbis impenditur</quote>. » In Cod. Theodos. lib. 15. tit. 5.
+                  universi obsequium orbis impenditur. »</quote> In Cod. Theodos. lib. 15. tit. 5.
                 l. 5.</note>. <quote>« Nous défendons aux peuples de toutes les villes de notre
                 Empire tous les divertissements du Théâtre et du Cirque, le Dimanche, qui est le
                 premier jour de la semaine, le jour de la naissance de Notre Seigneur Jésus-Christ,
@@ -6536,10 +6502,9 @@
                 avez renoncé au diable, et à ses spectacles ; et par conséquent il faut de nécessité
                 qu’en allant aux spectacles volontairement et avec dessein, vous reconnaissiez que
                 vous retournez au diable, car en même temps vous avez renoncé à l’un et à l’autre,
-                et avez confessé que l’un et l’autre sont</quote>
-              <pb n="113" xml:id="p113"/>
-              <quote>la même chose ; si bien que si vous retournez à l’un, il est véritable que vous
-                retournez à l’autre.</quote>
+                et avez confessé que l’un et l’autre sont<pb n="113" xml:id="p113"/> la même chose ;
+                si bien que si vous retournez à l’un, il est véritable que vous retournez à
+                l’autre.</quote>
             </p>
             <p>
               <quote>« En vous faisant baptiser vous dites : Je renonce au Diable, à ses pompes, à
@@ -6667,10 +6632,9 @@
               Libertins, et des Païens, qui est aussi le raisonnement de l’Auteur de la
               Dissertation.</p>
             <p>Mais voici la réponse de S. Chrysostome, qui est le sentiment des véritables
-              Chrétiens. <quote>« Au contraire,</quote>
-              <seg type="exquote">dit ce grand Prélat,</seg>
-              <quote>en détruisant les jeux du Théâtre, vous ne détruirez pas les Lois ; mais vous
-                détruirez l’iniquité, et vous étoufferez toute la peste de la ville. »</quote></p>
+              Chrétiens. <quote>« Au contraire, <seg type="exquote">dit ce grand Prélat,</seg>en
+                détruisant les jeux du Théâtre, vous ne détruirez pas les Lois ; mais vous détruirez
+                l’iniquité, et vous étoufferez toute la peste de la ville. »</quote></p>
             <p>Enfin, comme l’Auteur de la Dissertation semble ignorer la raison pour laquelle les
               Empereurs Chrétiens ont fait ces Lois que nous avons rapportées ci-dessus, et combien
               sous leur Règne on estimait que les Spectacles étaient indignes des Chrétiens ; il est
@@ -6786,12 +6750,11 @@
               à son Sacre renouvela dans Constantinople tous les Spectacles des Anciens, ceux du
               Cirque, de l’Hippodrome, et du Théâtre ; le Roi Philippe Auguste par un Edit exprès
               chassa tous les Bateleurs hors du Royaume de France. <quote>« Le Roi Philippe
-                Auguste</quote><seg type="exquote">, dit du Pleix,</seg>
-              <quote>consacra les prémices de sa Royauté à la gloire de Dieu ; car soudain après son
-                Couronnement, il bannit de sa Cour les joueurs d’instruments, les Bateleurs,
-                Comédiens et Farceurs, comme gens qui ne servent qu’à efféminer les hommes, et les
-                exciter à la volupté, par mouvement, discours, et actions sales, et
-                lascives. »</quote></p>
+                  Auguste<seg type="exquote">, dit du Pleix,</seg>consacra les prémices de sa
+                Royauté à la gloire de Dieu ; car soudain après son Couronnement, il bannit de sa
+                Cour les joueurs d’instruments, les Bateleurs, Comédiens et Farceurs, comme gens qui
+                ne servent qu’à efféminer les hommes, et les exciter à la volupté, par mouvement,
+                discours, et actions sales, et lascives. »</quote></p>
             <p>Je demande à l’Auteur de la Dissertation laquelle de ces deux actions est digne du
               Christianisme ? Il n’oserait nier que ce ne soit celle du Roi de France ; puisque elle
               est autant conforme aux règles et aux maximes de l’Evangile, aux décrets des Conciles,
@@ -6912,7 +6875,7 @@
                 estime encore plus misérables de demander des spectacles, etc. Je ne m’étonne plus
                 des malheurs qui vous sont arrivés. Votre ville a été trois fois saccagé, et vous ne
                 vous en êtes pas corrigés ; c’est pour cela que vous avez mérité de périr pour la
-                quatrième fois. » </quote></p>
+                quatrième fois. »</quote></p>
             <p><pb n="122" xml:id="p122"/>Il ne faut donc pas s’étonner aussi que le Règne de
               Baudouin ait été si court et si malheureux ; puisqu’il avait attiré sur lui
               l’indignation de Dieu, en profanant son Sacre par des spectacles qui sont injurieux à
@@ -7023,29 +6986,26 @@
           </div>
           <div>
             <head>Dissertation pag. 100. 101. etc. 102.</head>
-            <p>
-              <quote>« Et sans rechercher des exemples de plus loin, on sait que dans les derniers
+
+            <quote><p>« Et sans rechercher des exemples de plus loin, on sait que dans les derniers
                 temps les Spectacles étaient en si bonne estime, et si fréquentés, qu’il y avait
                 deux places d’honneur dans le Théâtre, l’une à la main droite pour le Pape, et
-                l’autre à la main gauche pour l’Empereur<note place="margin" resp="author"><p>
-                    <quote>« Pontifex ob beneficium a Venetis susceptum, Sebastiano Duci, et ejus
-                      successoribus, ac Senatui Veneto, privilegia concessit et c.</quote></p>
-                  <p><quote>« 4. Quod Venetorum Principi tertiam sedem in Theatro fieri fecit, cum
-                      prius duæ tantum in Papæ Theatro sedes essent, quarum dexteram, Pontifex,
-                      sinistram vero Cæsar tenet. »</quote> Baronius ad ann. 1177.</p>
+                l’autre à la main gauche pour l’Empereur<note place="margin" resp="author">
+                  <quote><p>« Pontifex ob beneficium a Venetis susceptum, Sebastiano Duci, et ejus
+                      successoribus, ac Senatui Veneto, privilegia concessit et c.</p><p>4. Quod
+                      Venetorum Principi tertiam sedem in Theatro fieri fecit, cum prius duæ tantum
+                      in Papæ Theatro sedes essent, quarum dexteram, Pontifex, sinistram vero Cæsar
+                      tenet. »</p></quote><p> Baronius ad ann. 1177.</p>
                 </note> : et que les Vénitiens ayant fait l’accommodement d’Alexandre III. et de
                 Frédéric II. reçurent du Pape plusieurs privilèges en reconnaissance de la retraite
                 qu’ils lui avaient donnée, et de la pacification des affaires d’Italie. Et entre
-                autres, le droit d’avoir la troisième place pour le Duc au Théâtre du
-              Pape.</quote></p>
+                autres, le droit d’avoir la troisième place pour le Duc au Théâtre du Pape.</p><p>Il
+                ne faut donc plus employer contre le Théâtre de notre temps ces grandes paroles de
+                zèle, et de foudre que les anciens Pères de l’Eglise ont autrefois prononcées : et
+                l’on ne doit point condamner un divertissement que les Papes, et les Princes
+                Chrétiens ont approuvé depuis qu’il a perdu les caractères de l’impiété qui le
+                rendaient abominable. »</p></quote>
 
-            <p>
-              <quote>« Il ne faut donc plus employer contre le Théâtre de notre temps ces grandes
-                paroles de zèle, et de foudre que les anciens Pères de l’Eglise ont autrefois
-                prononcées : et l’on ne doit point condamner un divertissement que les Papes, et les
-                Princes Chrétiens ont approuvé depuis qu’il a perdu les caractères de l’impiété qui
-                le rendaient abominable. »</quote>
-            </p>
           </div>
           <div>
             <head>X. Réfutation.</head>
@@ -7166,7 +7126,7 @@
             <p>Il faut néanmoins ajouter ici que l’Auteur de la Dissertation se trompe d’ordinaire
               dans ses citations, <pb n="129" xml:id="p129"/>car rapportant l’histoire dont je viens
               de parler, il cite Baronius : Or il est certain que Baronius la réfute telle qu’elle
-              est rapportée dans la Dissertation, comme étant fabuleuse<quote>. « Cette célèbre
+              est rapportée dans la Dissertation, comme étant fabuleuse <quote>« Cette célèbre
                   histoire<seg type="exquote">, dit-il<note place="margin" resp="author"
                       ><quote>« Historia nobilissima anilis fabulæ admissione vilescit. »</quote>
                     Baronius ad ann. 1177.</note>,</seg> est rendue méprisable par les fables
@@ -7181,7 +7141,7 @@
             <p>Le Pape Gélase écrivant contre le Sénateur Andromaque, et contre les autres Romains,
               qui s’opposaient à l’abolition des Spectacles des Lupercales : <quote>« Si tant de
                 vains spectacles<seg type="exquote">, dit-il<note place="margin" resp="author"
-                        ><p><quote>« Si plurima genera vanitatum multis acta sæculis probantur esse
+                        ><quote><p>« Si plurima genera vanitatum multis acta sæculis probantur esse
                         sublata ; cur portio quantovis tempore ventilata non possit auferri ? Si
                         temporibus præscribitur, imputate majoribus vestris, qui cum hac temporis
                         præscriptione non usi sint, posse quod superfluum est, et debere removeri,
@@ -7197,10 +7157,9 @@
                         salubre ; merito quandocumque tolli non debuit. Si nec salubre, nec divinum,
                         causandum tibi magis est, cur tardius auferatur quod superstitiosum constat,
                         et vanum, quod certe Christianæ professioni non convenire manifestum
-                        est.</quote></p>
-                    <p><quote>« Postremo quod ad me pertinet, nullus Baptisatus, nullus Christianus
-                        hoc celebret, et soli hoc Pagani, quorum ritus est, exequantur, me
-                        pronunciare convenit Christianis ista perniciosa, et funesta indubitanter
+                        est.</p><p>Postremo quod ad me pertinet, nullus Baptisatus, nullus
+                        Christianus hoc celebret, et soli hoc Pagani, quorum ritus est, exequantur,
+                        me pronunciare convenit Christianis ista perniciosa, et funesta indubitanter
                         existere ; quid me incusas si quod professio nomini inimicum est, a
                         consortibus professionis Christianæ pronuntio submovendum ? Ego certe
                         absolvam conscientiam meam : ipsi videant qui justis admonitionibus obedire
@@ -7216,8 +7175,9 @@
                         negligentiam accusare non audeo prædecessorum, cum magis credam fortasse
                         tentasse eos ut hæc pravitas tolleretur ; et quasdam extitisse causas, et
                         contrarias voluntates quæ eorum intentionibus præpedirent, sicut ne nunc
-                        quidem vos istos absistere insanis conatibus velle perpenditis. »</quote>
-                      <hi rend="i">Santus Gelasius Papa ad versus
+                        quidem vos istos absistere insanis conatibus velle
+                      perpenditis. »</p></quote>
+                    <p><hi rend="i">Santus Gelasius Papa ad versus
                   Andromachum.</hi></p></note>,</seg> qui avaient été en usage auparavant durant
                 plusieurs Siècles, ont été justement abolis ; pourquoi n’en pourra-t-on pas abolir
                 un qui reste, quelque temps qu’il y ait qu’on en use. Si vous alléguez la
@@ -7281,19 +7241,16 @@
               les défendre les jours de Fêtes, et les Vendredis ; comme la Lettre que l’Evêque
               d’Anagni écrivit au Pape Paul V. le 18. May 1600. nous l’apprend en ces termes<note
                 place="margin" resp="author">Lettre de l’Evêque d’Anagni au Pape Paul V.</note>.</p>
-            <p>
-              <quote>« Puisqu’il a plu à Votre Sainteté que je ne fusse pas seulement chargé de
+
+            <quote><p>« Puisqu’il a plu à Votre Sainteté que je ne fusse pas seulement chargé de
                 veiller à mon propre salut, mais encore de coopérer à celui des autres, pour
                 remédier aux désordres, et aux excès par lesquels Dieu était offensé dans mon
                 Diocèse ; J’ai ordonné dans l’assemblée Synodale qu’on célèbrerait à l’avenir les
                 jours de Dimanches, et les Fêtes avec la révérence et la dévotion convenable : et
                 pour cela j’ai défendu en ces mêmes jours les danses et toutes sortes de débauches ;
                 la lutte et tous les Spectacles du Théâtre, comme une profanation manifeste : J’ai
-                menacé les contrevenants des censures Ecclésiastiques. </quote>
-            </p>
-            <p>
-              <pb n="132" xml:id="p132"/>
-              <quote>« Et mon dessein aurait heureusement réussi pour la gloire de Dieu, et pour le
+                menacé les contrevenants des censures Ecclésiastiques. »<pb n="132" xml:id="p132"/>
+              </p><p>Et mon dessein aurait heureusement réussi pour la gloire de Dieu, et pour le
                 bien des âmes, n’eût été l’exemple d’une permission, qu’on dit avoir été accordée à
                 la ville d’Alatre, voisine de mon Diocèse, contre une ordonnance semblable à la
                 mienne ; et comme l’on croit, sans que votre Sainteté en ait eu aucune
@@ -7306,22 +7263,17 @@
                 ne laisse pas d’être coupable devant Dieu ; les fidèles néanmoins, qui sont sous ma
                 charge, et que je dois régler et conduire, s’appuient sur cet exemple : et ils ont
                 pris même cette liberté de déclarer qu’ils auront recours à votre Sainteté pour
-                éviter de faire ce que je ne désire que pour leur salut.</quote>
-            </p>
-            <p>
-              <quote>« C’est pour cela, très Saint Père, que j’ai cru vous devoir écrire avec
-                confiance ce peu de mots, et vous envoyer en même temps un excellent ouvrage composé
-                par S. Charles Borromée, qui porta Grégoire XIII. prédécesseur de Votre Sainteté ; à
-                qui Saint Charles même le fit voir, à terminer les contestations qui troublaient sur
-                ce sujet la Ville de Milan, par ses Lettres Apostoliques ; et à défendre même dans
-                Rome, comme nous lisons dans la vie de S. Charles, les masques, et toutes sortes des
-                spectacles, les jours de Fêtes et les Vendredis.</quote>
-            </p>
-            <p>
-              <quote>« Et ce règlement a été si fidèlement observé, que cela seul devrait obliger
-                mon peuple, sans attendre de nouvelles ordonnances, à se régler lui-même sur ce
-                sujet. »</quote>
-            </p>
+                éviter de faire ce que je ne désire que pour leur salut.</p><p>C’est pour cela, très
+                Saint Père, que j’ai cru vous devoir écrire avec confiance ce peu de mots, et vous
+                envoyer en même temps un excellent ouvrage composé par S. Charles Borromée, qui
+                porta Grégoire XIII. prédécesseur de Votre Sainteté ; à qui Saint Charles même le
+                fit voir, à terminer les contestations qui troublaient sur ce sujet la Ville de
+                Milan, par ses Lettres Apostoliques ; et à défendre même dans Rome, comme nous
+                lisons dans la vie de S. Charles, les masques, et toutes sortes des spectacles, les
+                jours de Fêtes et les Vendredis.</p><p>Et ce règlement a été si fidèlement observé,
+                que cela seul devrait obliger mon peuple, sans attendre de nouvelles ordonnances, à
+                se régler lui-même sur ce sujet. »</p></quote>
+
           </div>
         </div>
         <div>
@@ -7450,7 +7402,7 @@
                   accommodatissimas fabulas eligunt, qui enim voce freti sunt. Epigonos, Medumque :
                   qui gestum, Menalippam, Clytemnestram : Semper Rupilius, quem ego memini,
                   Antiopam, non sæpe Æsopus Ajacem : Ergo Histrio hoc videbit in Scena, non videbit
-                  sapiens in vita </quote>? » Cic. <hi rend="i">de Offic</hi>. lib. 1.</note> :
+                  sapiens in vita ? »</quote> Cic. <hi rend="i">de Offic</hi>. lib. 1.</note> :
                 <quote>« Que chacun connaisse son esprit, et que sans se flatter il juge lui-même de
                 ses vertus, et de ses vices, afin qu’il ne semble pas qu’il ait moins de prudence,
                 et de jugement que les Scéniques, qui ne choisissent pas toujours les meilleures
@@ -7655,7 +7607,7 @@
                 Alors Solon frappant de son bâton contre terre ; <quote>« mais nous ne tarderons
                   guères, dit-il, à voir dans nos contrats, et dans le commerce <pb n="142"
                     xml:id="p142"/> ces mêmes faussetés que nous louons à présent, et que nous
-                  approuvons dans nos jeux »  »</quote></quote>. </p>
+                  approuvons dans nos jeux »</quote> »</quote>. </p>
             <p>Diogène Laërce raconte que<note place="margin" resp="author"><quote>« Euripide ita de
                   virtute disserente, ut diceret, præclarum esse temere eam dimittere ; surgens
                   egressus est, turpe esse dicens, mancipium si non inveniatur, dignum inquisitione
@@ -7678,7 +7630,7 @@
                 allait les réciter sur le Théâtre d’Athènes consacré à Bacchus, il rencontra
                 Socrate, qui le toucha tellement par ses discours, qu’il jeta aussitôt dans le feu
                 les Tragédies qu’il avait faites, disant, <quote>« Vulcain viens à mon aide, Platon
-                  a besoin de toi ! »</quote>. »</quote></p>
+                  a besoin de toi ! ».</quote> »</quote></p>
             <p>Ce grand Philosophe d’Athènes jugeait donc que les Tragédies et leurs représentations
               étaient indignes de ceux qui s’appliquent à l’étude de la sagesse.</p>
             <p>Enfin les plus sages de la Grèce estimaient que les Jeux et les Spectacles étaient
@@ -7756,33 +7708,30 @@
           </div>
           <div>
             <head>Dissertation. pag. 191. et 192.</head>
-            <p>
-              <quote>« Mais parmi les Romains, les Patrices, c’est-à-dire les Nobles qui avaient la
+
+            <quote><p>« Mais parmi les Romains, les Patrices, c’est-à-dire les Nobles qui avaient la
                 plus grande autorité, ne furent pas si favorables à ces Scéniques, Histrions,
                 Farceurs, Bouffons, et Bateleurs que nous avons décrits ; car ils les notèrent
                 d’infamie par les Lois, et les déclarèrent indignes de posséder aucunes charges
                 publiques, de porter les armes sous leurs Généraux, et d’avoir le droit de suffrage
                 aux assemblées de leurs Bourgeois, et nous ne voyons point que le peuple qui les
                 regardait comme les Auteurs de tous leurs plaisirs, ait jamais obtenu, ni seulement
-                demandé leur rétablissement.</quote>
-            </p>
-            <p>
-              <quote>« Mais dans cette rigueur qu’ils exercèrent contre eux, ils ne comprirent
-                jamais les Atellanes, les Comédiens, ni les Tragédiens : Ceux-ci furent toujours
-                bien estimés et bien reçus des Magistrats les plus puissants, des personnages les
-                plus illustres, et de tous les gens d’honneur : l’excellence de leurs ouvrages, la
-                beauté de leurs représentations, et l’honnêteté de leurs vies, qui les
-                distinguait des autres Acteurs leur fit recevoir un traitement bien dissemblable ;
-                et c’est en quoi presque tous les Ecrivains des derniers siècles se sont abusés.
-                J’ai demandé compte à ma mémoire de tout ce que j’avais lu, j’ai rappelé toutes mes
-                vieilles idées, et j’ai cherché dans tous les livres qui me sont tombés sous la
-                main, et je n’ai rien trouvé qui ne m’ait fait connaître clairement, que les Acteurs
-                du poème Dramatique ont toujours été maintenus dans tous les droits, et les honneurs
-                de la <pb n="145" xml:id="p145"/> République Romaine ; et que les Scéniques
-                seulement, les Histrions, les Mimes, et les Bateleurs exerçant l’art de bouffonner,
-                ont été marqués de cette infamie, qui fait soulever tant de gens par ignorance, ou
-                par scrupule contre le Théâtre. »</quote>
-            </p>
+                demandé leur rétablissement.</p><p>Mais dans cette rigueur qu’ils exercèrent contre
+                eux, ils ne comprirent jamais les Atellanes, les Comédiens, ni les Tragédiens :
+                Ceux-ci furent toujours bien estimés et bien reçus des Magistrats les plus
+                puissants, des personnages les plus illustres, et de tous les gens d’honneur :
+                l’excellence de leurs ouvrages, la beauté de leurs représentations, et l’honnêteté
+                de leurs vies, qui les distinguait des autres Acteurs leur fit recevoir un
+                traitement bien dissemblable ; et c’est en quoi presque tous les Ecrivains des
+                derniers siècles se sont abusés. J’ai demandé compte à ma mémoire de tout ce que
+                j’avais lu, j’ai rappelé toutes mes vieilles idées, et j’ai cherché dans tous les
+                livres qui me sont tombés sous la main, et je n’ai rien trouvé qui ne m’ait fait
+                connaître clairement, que les Acteurs du poème Dramatique ont toujours été maintenus
+                dans tous les droits, et les honneurs de la <pb n="145" xml:id="p145"/> République
+                Romaine ; et que les Scéniques seulement, les Histrions, les Mimes, et les Bateleurs
+                exerçant l’art de bouffonner, ont été marqués de cette infamie, qui fait soulever
+                tant de gens par ignorance, ou par scrupule contre le Théâtre. »</p></quote>
+
           </div>
           <div>
             <head>III. Réfutation.</head>
@@ -7844,39 +7793,39 @@
                 plus il doit s’en éloigner. »</quote></p>
             <p>Cicéron encore dans le quatrième livre de la <hi rend="i">République</hi> nous
               apprend que les Romains notaient d’infamie les Comédiens ; ce qui est confirmé par
-              S. Augustin, qui rapporte les paroles de cet Orateur. <quote>« Nous apprenons de
-                  Cicéron<seg type="exquote">, dit-il<note place="margin" resp="author"
-                      ><quote>« Quid autem hinc senserint Romani veteres, Cicero testatur in libris
-                      quos de Republica scripsit, ubi Scipio disputans ait : Numquam Comœdiæ nisi
-                      consuetudo vitæ pateretur, probare sua Theatris flagitia potuissent. et Græci
-                      quidam antiquiores vitiosæ suæ opinionis quamdam convenientiam servaverunt :
-                      et c. »</quote> Cic. in lib. 4. <hi rend="i">de Repub</hi>. S. August. l. 2.
-                      <hi rend="i">de civit. Dei</hi>, cap. 9.</note>,</seg> dans ses livres de la
-                République, ce que les Anciens Romains jugeaient de la Scène ; car il y introduit
-                Scipion l’Africain qui parle ainsi : </quote></p>
-            <p><quote><quote>« On n’eût jamais approuvé les Comédies, et les crimes qu’elles
+              S. Augustin, qui rapporte les paroles de cet Orateur. </p>
+            <quote><p>« Nous apprenons de Cicéron<seg type="exquote">, dit-il<note place="margin"
+                    resp="author"><quote>« Quid autem hinc senserint Romani veteres, Cicero testatur
+                      in libris quos de Republica scripsit, ubi Scipio disputans ait : Numquam
+                      Comœdiæ nisi consuetudo vitæ pateretur, probare sua Theatris flagitia
+                      potuissent. et Græci quidam antiquiores vitiosæ suæ opinionis quamdam
+                      convenientiam servaverunt : et c. »</quote> Cic. in lib. 4. <hi rend="i">de
+                      Repub</hi>. S. August. l. 2. <hi rend="i">de civit. Dei</hi>, cap.
+                  9.</note>,</seg> dans ses livres de la République, ce que les Anciens Romains
+                jugeaient de la Scène ; car il y introduit Scipion l’Africain qui parle ainsi : </p>
+              <p><quote>« On n’eût jamais approuvé les Comédies, et les crimes qu’elles
                   représentaient sur le Théâtre, si les mœurs des hommes qui étaient souillés des
                   mêmes vices, ne l’eussent <pb n="147" xml:id="p147"/>souffert. Quant aux Grecs,
                   quelques-uns des plus anciens ont traité la Comédie, selon l’opinion qu’ils en
-                  avaient dans le dérèglement de leur vie, etc. »  »</quote></quote> Et après avoir
-              allégué les sentiments des Grecs sur ce sujet, il rapporte ensuite ceux des Romains en
-              ces termes<note place="margin" resp="author"><quote>« Romani quamvis jam superstitione
-                  noxia premerentur, ut illos Deos colerent quos videbant sibi voluisse scenicas
-                  turpitudines consecrari ;suæ tamen dignitatis memores, ac pudoris, actores talium
-                  fabularum nequaquam honoraverunt more Græcorum ; sed sicut apud Ciceronem Scipio
-                  loquitur, cum artem ludicram, scenamque totam probo ducerent ; genus id hominum
-                  non modo honore civium reliquorum carere, sed etiam tribu moveri notatione
-                  censoria voluerunt. »</quote> Ibid. cap. 13.</note> : <quote>« Encore que les
-                Romains, par une pernicieuse superstition, adorassent ces Dieux qu’ils voyaient
-                avoir demandé que les ordures de la Scène leur fussent consacrées, toutefois se
-                souvenant de leur dignité, et ayant devant les yeux l’honnêteté et la pudeur, ils
-                n’ont pas communiqué, comme les Grecs, les honneurs de l’Etat aux Acteurs de ces
-                fables, et de ces Comédies : mais ainsi que Scipion parle dans ce livre de Cicéron,
-                estimant que l’art des jeux, et tous les spectacles de la Scène étaient des choses
-                honteuses, et infâmes, non seulement ils ont privé ces sortes de gens qui en sont
-                les Acteurs, des honneurs et des dignités, dont la porte était ouverte aux autres
-                citoyens : mais ils les ont même jugés dignes d’être notés par les Censeurs, pour
-                 être exclus de leurs Tribus. »</quote></p>
+                  avaient dans le dérèglement de leur vie, etc. »</quote></p></quote>
+            <p>Et après avoir allégué les sentiments des Grecs sur ce sujet, il rapporte ensuite
+              ceux des Romains en ces termes<note place="margin" resp="author"><quote>« Romani
+                  quamvis jam superstitione noxia premerentur, ut illos Deos colerent quos videbant
+                  sibi voluisse scenicas turpitudines consecrari ;suæ tamen dignitatis memores, ac
+                  pudoris, actores talium fabularum nequaquam honoraverunt more Græcorum ; sed sicut
+                  apud Ciceronem Scipio loquitur, cum artem ludicram, scenamque totam probo
+                  ducerent ; genus id hominum non modo honore civium reliquorum carere, sed etiam
+                  tribu moveri notatione censoria voluerunt. »</quote> Ibid. cap. 13.</note> :
+                <quote>« Encore que les Romains, par une pernicieuse superstition, adorassent ces
+                Dieux qu’ils voyaient avoir demandé que les ordures de la Scène leur fussent
+                consacrées, toutefois se souvenant de leur dignité, et ayant devant les yeux
+                l’honnêteté et la pudeur, ils n’ont pas communiqué, comme les Grecs, les honneurs de
+                l’Etat aux Acteurs de ces fables, et de ces Comédies : mais ainsi que Scipion parle
+                dans ce livre de Cicéron, estimant que l’art des jeux, et tous les spectacles de la
+                Scène étaient des choses honteuses, et infâmes, non seulement ils ont privé ces
+                sortes de gens qui en sont les Acteurs, des honneurs et des dignités, dont la porte
+                était ouverte aux autres citoyens : mais ils les ont même jugés dignes d’être notés
+                par les Censeurs, pour  être exclus de leurs Tribus. »</quote></p>
             <p>Tite-Live parlant d’un certain Ariston<note place="margin" resp="author"
                   ><quote>« Aristoni cuidam Tragico actori et genus et fortuna honesta erant ; nec
                   ars, quia nihil tale apud Græcos pudori est, ea deformabat. »</quote> Tit. Liv. l.
@@ -7927,20 +7876,19 @@
               <quote>« Comment donc<seg type="exquote">, dit-il<note place="margin" resp="author"
                       ><quote>« Cur ergo non hujusmodi etiam dæmoniis penetrabiles
                       fiant ?....Constant et mulieri linteum in somnis ostensum ejus diei nocte, qua
-                      Tragœdum audierat, cum exprobatione nominatim</quote>
-                    <quote>Tragœdi, nec ultra quintum diem eam mulierem in sæculo fuisse. Quot
-                      utique et alia documenta cesserunt, de his qui cum diabolo apud spectacula
-                      communicando, a Domino exciderunt ? Nemo enim potest duobus dominis servire :
-                      quid luci, cum tenebris ? quid vitæ et morti ? »</quote> Ibid. cap.
-                  26.</note>,</seg> ces gens qui vont aux spectacles, ne seraient-ils pas exposés à
-                la tyrannie du Démon ?… Il est constant qu’une femme étant allée à une Tragédie, la
-                nuit suivante, elle vit en songe un suaire, et il lui sembla qu’on lui reprochait la
-                faute qu’elle avait commise d’avoir assisté à cette Tragédie, en lui représentant
-                même la personne de l’Acteur ; ce qui l’effraya tellement qu’elle mourut cinq jours
-                après. Combien d’autres exemples y a-t-il de ceux qui en suivant le parti du démon
-                dans les spectacles, ont secoué le joug du Seigneur ? Car personne ne peut servir
-                deux maîtres : quel commerce peut-il y avoir entre la lumière, et les ténèbres,
-                entre la vie et la mort ? »</quote></p>
+                      Tragœdum audierat, cum exprobatione nominatim. Tragœdi, nec ultra quintum diem
+                      eam mulierem in sæculo fuisse. Quot utique et alia documenta cesserunt, de his
+                      qui cum diabolo apud spectacula communicando, a Domino exciderunt ? Nemo enim
+                      potest duobus dominis servire : quid luci, cum tenebris ? quid vitæ et
+                      morti ? »</quote> Ibid. cap. 26.</note>,</seg> ces gens qui vont aux
+                spectacles, ne seraient-ils pas exposés à la tyrannie du Démon ?… Il est constant
+                qu’une femme étant allée à une Tragédie, la nuit suivante, elle vit en songe un
+                suaire, et il lui sembla qu’on lui reprochait la faute qu’elle avait commise d’avoir
+                assisté à cette Tragédie, en lui représentant même la personne de l’Acteur ; ce qui
+                l’effraya tellement qu’elle mourut cinq jours après. Combien d’autres exemples y
+                a-t-il de ceux qui en suivant le parti du démon dans les spectacles, ont secoué le
+                joug du Seigneur ? Car personne ne peut servir deux maîtres : quel commerce peut-il
+                y avoir entre la lumière, et les ténèbres, entre la vie et la mort ? »</quote></p>
             <p>Enfin Tertullien représente les peines que les <pb n="149" xml:id="p149"/>Acteurs des
               Tragédies, et des autres Spectacles, souffriront dans l’Enfer : <quote>« Alors<seg
                   type="exquote">, dit-il<note place="margin" resp="author"><quote>« Tunc magis
@@ -7978,7 +7926,7 @@
             <head>Dissertation <hi rend="i">pag</hi>. 193. 194. et 195.</head>
             <p>
               <quote>« Examinons quelques textes les plus apparents, que l’on allègue ordinairement
-                pour défendre cette fausse opinion. </quote>
+                pour défendre cette fausse opinion. »</quote>
             </p>
             <p>
               <pb n="150" xml:id="p150"/>
@@ -8035,7 +7983,7 @@
                       sed Roscius artem ludicram commendavit. »</quote> Val. Max. l. 8. c.
                   7.</note>,</seg> ars ludicra<seg type="exquote">, c’est-à-dire, l’art de jouer des
                   Comédies,</seg> qui a rendu Roscius recommandable ; mais c’est Roscius qui a rendu
-                cet art recommandable</quote>. » Et en un autre endroit. <quote>« Il est certain<seg
+                cet art recommandable. »</quote> Et en un autre endroit. <quote>« Il est certain<seg
                   type="exquote">, dit-il<note place="margin" resp="author"><quote>« Constat Æsopum,
                       Rosciumque ludicræ artis peritissimos, Hortensio causas agente, in corona
                       frequentes extitisse. »</quote> Idem in cod. lib. 8. cap. 10.</note>,</seg>
@@ -8075,7 +8023,7 @@
                       ><quote>« Quis neget opus esse Oratori, in hoc oratorio motu statuque Roscii
                       gestum, et venustatem »</quote>, Cic. l. 1. de orat.</note>,</seg> qu’un
                 Orateur n’ait pas besoin du geste, et de la bonne grâce du Comédien Roscius, dans
-                les actions du Barreau</quote> ? »</p>
+                les actions du Barreau ? »</quote></p>
             <p><quote>« N’oublions pas,<seg type="exquote">dit Valère Maxime<note place="margin"
                     resp="author"><quote>« Ne Roscius quidem subtrahatur scenicæ industriæ
                       notissimum exemplum, qui nullum unquam spectanti populo gestum, nisi quem domi
@@ -8113,7 +8061,7 @@
                 soutenons fortement, que nous voulons inculquer, que nous voulons imprimer dans les
                 esprits : et les mouvements impétueux doivent être exprimés encore plus lentement.
                 Roscius parlait vite, et Esope parlait gravement ; à cause que celui-là jouait des
-                Comédies, et celui-ci des Tragédies</quote>. »</p>
+                Comédies, et celui-ci des Tragédies. »</quote></p>
             <p>Peut-on rien alléguer de plus exprès pour détruire entièrement tout ce que l’Auteur
               de la Dissertation avance ici sans aucune preuve, que ce que Quintilien dit encore
               dans le sixième livre chap. 2. où il montre que les Histrions, et les Comédiens
@@ -8317,19 +8265,17 @@
           <div>
             <head>Dissertation pag. 197.</head>
             <p>
-              <quote>« Et Justinien permet aux femmes</quote>
-              <note place="margin" resp="author">L. Imperial. Cod. de nupt.</note>
-              <quote> qui s’étaient engagées aux Jeux scéniques par la faiblesse de leur sexe, de
-                recourir à la bonté de l’Empereur, pour être restituées en leur premier honneur, et
-                bonne renommée quand elles voulaient </quote>
-              <pb n="158" xml:id="p158"/>
-              <quote>retourner à la pratique d’une vie honnête. Ce qui témoigne assez que l’infamie
-                ne s’était point étendue sur les Comédiens, ni sur les Tragédiens, parce que les
-                femmes n’y jouaient point, et que ces Acteurs étant bien plus modestes, et plus
-                estimés, que tous les Mimes, et Bouffons de ces jeux, on leur eût bien plus
-                facilement accordé cette grâce ; et cette loi ne les eût pas oubliés, s’ils avaient
-                été compris en celle dont la sévérité est ici modérée par la douceur de
-                Justinien. »</quote>
+              <quote>« Et Justinien permet aux femmes <note place="margin" resp="author">L.
+                  Imperial. Cod. de nupt.</note> qui s’étaient engagées aux Jeux scéniques par la
+                faiblesse de leur sexe, de recourir à la bonté de l’Empereur, pour être restituées
+                en leur premier honneur, et bonne renommée quand elles voulaient<pb n="158"
+                  xml:id="p158"/> retourner à la pratique d’une vie honnête. Ce qui témoigne assez
+                que l’infamie ne s’était point étendue sur les Comédiens, ni sur les Tragédiens,
+                parce que les femmes n’y jouaient point, et que ces Acteurs étant bien plus
+                modestes, et plus estimés, que tous les Mimes, et Bouffons de ces jeux, on leur eût
+                bien plus facilement accordé cette grâce ; et cette loi ne les eût pas oubliés,
+                s’ils avaient été compris en celle dont la sévérité est ici modérée par la douceur
+                de Justinien. »</quote>
             </p>
           </div>
           <div>
@@ -8541,8 +8487,8 @@
               pour éclaircir encore cette vérité par quelque exemple, il suffit donc rapporter un du
               plus <pb n="164" xml:id="p164"/>retenu de tous les Poètes Comiques, lequel saint
               Augustin représente en ces propres termes.</p>
-            <p>
-              <quote>« Terence <seg type="exquote">, dit-il <note place="margin" resp="author"
+
+            <quote><p>« Terence <seg type="exquote">, dit-il <note place="margin" resp="author"
                       ><quote>« Terentius inducit nequam adolescentem proponentem sibi Jovem ad
                       exemplum stupri, dum spectat tabulam quandam pictam in pariete, ubi inerat
                       pictura hæc ; Jovem quo pacto Danaæ misisse aiunt in gremium quondam imbrem
@@ -8560,12 +8506,10 @@
                 celui que le Ciel adore. Un Dieu, dit-il, l’a bien voulu faire. Mais quel Dieu ?
                 Celui qui fait trembler les voûtes du Ciel par le bruit de son tonnerre. Et moi qui
                 ne suis qu’un des moindres d’entre les hommes, j’aurais honte d’imiter le plus grand
-                des Dieux ? Non certes. Aussi l’ai-je imité, et avec joie.</quote>
-            </p>
-            <p>
-              <quote>« N’est-il pas très vrai que ces paroles sont très propres pour faire commettre
-                aux hommes cette infamie avec plus de hardiesse ? »</quote>
-            </p>
+                des Dieux ? Non certes. Aussi l’ai-je imité, et avec joie. </p>
+              <p> N’est-il pas très vrai que ces paroles sont très propres pour faire commettre aux
+                hommes cette infamie avec plus de hardiesse ? »</p></quote>
+
             <p>Je demande à l’Auteur de la Dissertation s’il estime qu’un mari ait sujet d’être bien
               satisfait de voir sa femme se plaire à entendre ces ordures, et à les voir représenter
               malgré lui ? Mais si nous considérons encore les circonstances du lieu où l’on
@@ -8823,8 +8767,8 @@
           </div>
           <div>
             <head>Dissertation pag. 203. 204. 205. 206. et 207.</head>
-            <p>
-              <quote>« Mais pour donner encore plus de jour à l’explication de ces vieilles
+
+            <quote><p>« Mais pour donner encore plus de jour à l’explication de ces vieilles
                 autorités, il en faut apporter qui ne puissent recevoir de contredit, employer des
                 démonstrations infaillibles, et non pas des conjectures, et faire voir par des
                 preuves convaincantes que les Ecrivains des derniers siècles, qui ont étendu
@@ -8839,15 +8783,13 @@
                 quelquefois de plaisanteries. Et les Atellanes étaient les derniers, leurs Poèmes ne
                 contenant que des railleries, et des actions plus satiriques, et moins honnêtes,
                 quoiqu’ils y aient gardé toujours quelque modération. Cet ordre, et cette
-                distinction ne peuvent être révoqués en doute.</quote>
-            </p>
-            <p>
-              <quote>« Après quoi nous n’avons qu’à prendre le témoignage de Valère Maxime, pour
-                rendre inébranlable la vérité que nous avons avancée. C’était un Romain qui vivait
-                sous Auguste à la naissance de l’Empire, qui n’ignorait pas les lois de son pays, et
-                qui ne pouvait s’abuser en la connaissance du Théâtre de son temps, que l’on peut
-                dire avoir été lors en son éclat ; et voici comme il en parle. </quote>
-            </p>
+                distinction ne peuvent être révoqués en doute. </p>
+              <p> Après quoi nous n’avons qu’à prendre le témoignage de Valère Maxime, pour rendre
+                inébranlable la vérité que nous avons avancée. C’était un Romain qui vivait sous
+                Auguste à la naissance de l’Empire, qui n’ignorait pas les lois de son pays, et qui
+                ne pouvait s’abuser en la connaissance du Théâtre de son temps, que l’on peut dire
+                avoir été lors en son éclat ; et voici comme il en parle. »</p></quote>
+
             <p>
               <pb n="172" xml:id="p172"/>
               <quote>« “Les Atellanes étaient originairement venus d’Etrurie, et leurs fables
@@ -8882,7 +8824,7 @@
                 Théâtre des Romains »</quote> ; Mais c’est de plus un étrange aveuglement de
               s’engager à le prouver par des démonstrations infaillibles, et cependant être réduit à
               ne pouvoir avancer que de faux raisonnements, comme fait l’Auteur de la Dissertation
-              en cet endroit ; car « voici<quote> toutes ses démonstrations infaillibles, toutes ses
+              en cet endroit ; car <quote>« voici toutes ses démonstrations infaillibles, toutes ses
                 preuves convaincantes, toutes ses autorités qui ne peuvent recevoir de
                 contredit »</quote>.</p>
             <p>Les Atellanes, dit-il, n’étaient point notés d’infamie, comme Valère Maxime le
@@ -9004,8 +8946,8 @@
           </div>
           <div>
             <head>Dissertation pag. 208. et 209.</head>
-            <p>
-              <quote>« Et Macrobe soutient <note place="margin" resp="author"><quote>« Histriones
+
+            <quote><p>« Et Macrobe soutient <note place="margin" resp="author"><quote>« Histriones
                     non inter turpes habitos Cicero testimonio est, quem nullus ignorat Roscio, et
                     Æsopo Histrionibus tam familiariter usum, ut res rationesque eorum sua solertia
                     tueretur. Quod cum aliis multis tum ex epistolis quoque ejus
@@ -9018,13 +8960,11 @@
                 de Roscius, et d’Esope seulement ; et de ce qu’auparavant il avait montré que les
                 danses malhonnêtes, et désordonnées, qui étaient propres aux Bouffons, et vrais
                 Histrions, étaient condamnées par tous les Sages au siècle de ces deux célèbres
-                Acteurs.</quote>
-            </p>
-            <p>
-              <quote>« Sur quoi nous pouvons remarquer en passant, que dès l’âge de cet Auteur, la
-                langue latine dégénérant de sa pureté, le nom d’Histrions commençait à s’appliquer à
-                tous ceux qui s’exerçaient aux représentations du Théâtre. »</quote>
-            </p>
+                Acteurs. </p>
+              <p> Sur quoi nous pouvons remarquer en passant, que dès l’âge de cet Auteur, la langue
+                latine dégénérant de sa pureté, le nom d’Histrions commençait à s’appliquer à tous
+                ceux qui s’exerçaient aux représentations du Théâtre. »</p></quote>
+
           </div>
           <div>
             <head>XIV. Réfutation.</head>
@@ -9337,10 +9277,9 @@
               clairement que cela était estimé infâme et indigne de la noblesse de cet ordre.
                   <quote>« Vitellius<seg type="exquote">, dit Tacite<note place="margin"
                     resp="author"><quote>« Cautum severe ne equites Romani ludo, et Arena
-                      polluerentur. »</quote>
-                    <quote>Tacit. lib. 2.</quote>
-                    <hi rend="i">Histor.</hi></note>,</seg> défendit sévèrement aux Chevaliers
-                Romains, de se souiller de l’infamie du Théâtre, et de l’Arène. »</quote></p>
+                      polluerentur. »</quote> Tacit. lib. 2. <hi rend="i">Histor.</hi></note>,</seg>
+                défendit sévèrement aux Chevaliers Romains, de se souiller de l’infamie du Théâtre,
+                et de l’Arène. »</quote></p>
             <p>Hérodien confirme cette vérité, et nous fait voir que les Comédiens, les Conducteurs
               de chariots, aussi bien que les Mimes, étaient estimés infâmes et indignes des charges
               et des dignités de l’Empire ; de sorte que l’Empereur Héliogabale en ayant élevé
@@ -9506,7 +9445,7 @@
               quand il dit<note place="margin" resp="author"><quote>« Athletarum vero spectaculo
                   muliebrem sexum omnem adeo submovit, ut Pontificalibus ludis pugilum par
                   postulatum distulerit in sequentis diei matutinum tempus, edixeritque mulieres
-                  ante horam quintam venirent in Theatrum non placere</quote>. » Sueton. lib. 2. in
+                  ante horam quintam venirent in Theatrum non placere. »</quote> Sueton. lib. 2. in
                 Octavio Augusto.</note> : <quote>« Que l’Empereur Auguste défendit aux filles et aux
                 femmes le spectacle des Athlètes ; de sorte qu’aux jeux Pontificaux, le peuple lui
                 ayant demandé le combat de deux Athlètes, il remit à le donner jusques au matin du
@@ -10071,7 +10010,7 @@
                   hommes, j’aurais honte d’imiter le plus grand des Dieux ? Non certes : Aussi
                   l’ai-je imité avec joie. »</quote> N’est-il pas vrai que ces paroles sont très
                 propres pour faire commettre aux hommes cette infamie détestable avec plus de
-                hardiesse </quote>? » Et de même Ovide nous apprend que toutes les Comédies de
+                hardiesse ? »</quote> Et de même Ovide nous apprend que toutes les Comédies de
               Ménandre sont pleines d’intrigues d’amour<note place="margin" resp="author"
                   ><quote>« Fabula jucundi nulla est sine amore Menandri. »</quote> Ovid. in <hi
                   rend="i">Trist.</hi></note>.</p>
@@ -10120,7 +10059,7 @@
               les Comédies, qui sont des espèces de Spectacles ? car les choses spéciales sont
               toujours comprises dans les générales, et les parties dans leur tout<note
                 place="margin" resp="author"><quote>« Semper specialia generalibus insunt. »</quote>
-                <hi rend="i">147. de regul. Jur.</hi><quote>In toto et pars continetur.</quote>
+                <hi rend="i">147. de regul. Jur.</hi><quote>« In toto et pars continetur. »</quote>
                 <hi rend="i">Ibid. 113.</hi></note>.</p>
             <p>Il est aisé d’ailleurs de faire voir encore plus expressément, que les premiers
               Docteurs de l’Eglise ont condamné les Comédies, et les Tragédies : <quote>« A quoi me
@@ -10156,11 +10095,11 @@
                 s’expliquer bien plus par les postures, que par le discours. Et nous pouvons
                 découvrir son sentiment, quand il écrit <note place="margin" resp="author"><hi
                     rend="i">Idem de spectacul. c. 135.</hi></note>
-                <quote> : “Nous nous sommes séparés de votre Théâtre, parce que c’est un mystère
+                <quote>« Nous nous sommes séparés de votre Théâtre, parce que c’est un mystère
                   d’impudicité, où rien n’est approuvé que ce que l’on condamne ailleurs ; et tout
                   ce qu’il a de charmes pour plaire, ne vient que des gesticulations trop libres des
                   Atellanes et des honteuses représentations des Mimes, où les femmes se font voir
-                  sans aucun reste de pudeur. »  »</quote></quote>
+                  sans aucun reste de pudeur. »</quote> »</quote>
             </p>
             <p/>
           </div>
@@ -10813,7 +10752,7 @@
                 sont punis par les lois des Empereurs, est la note d’infamie, par laquelle ils sont
                 exclus des dignités, comme l’enseigne entre autres Lucas de Penna, qui ajoute que
                 parmi ces Histrions notés d’infamie, sont compris ceux qui montent sur la Scène et y
-                récitent des Comédies ; quoiqu’ils ne fassent point de farces....</quote></p>
+                récitent des Comédies ; quoiqu’ils ne fassent point de farces.... »</quote></p>
             <p>
               <quote>« La sixième peine établie contre eux, est que personne ne leur peut rien
                 donner pour la représentation de leurs pièces, suivant le même Canon Donare, tiré de
@@ -10952,12 +10891,12 @@
                 premiers Bateleurs qui n’y chantaient point et n’y dansaient point ; croyant par ce
                 moyen s’exempter de la peine des anciens Mimes et Bouffons : Mais parce qu’ils
                 y faisaient des railleries indécentes, et prononçaient plusieurs paroles impudentes,
-                ils furent condamnés par nos Théologiens</quote>
-              <note place="margin" resp="author">Ex notis in decret. Sorbona Epist.</note>
-              <quote>, qui conclurent que la turpitude du discours n’était pas moins condamnable que
-                celle des gestes du corps. Où nous devons remarquer qu’il n’est parlé que
-                d’Histrions, et Joueurs de bouffonneries, et non point de Tragédies et Comédies, qui
-                n’étaient pas encore en état d’être estimées, ou condamnées. »</quote>
+                ils furent condamnés par nos Théologiens <note place="margin" resp="author">Ex notis
+                  in decret. Sorbona Epist.</note>, qui conclurent que la turpitude du discours
+                n’était pas moins condamnable que celle des gestes du corps. Où nous devons
+                remarquer qu’il n’est parlé que d’Histrions, et Joueurs de bouffonneries, et non
+                point de Tragédies et Comédies, qui n’étaient pas encore en état d’être estimées, ou
+                condamnées. »</quote>
             </p>
             <p>
               <pb n="226" xml:id="p226"/>
@@ -11607,20 +11546,20 @@
               être exclus de la Communion, parce qu’ils sont des pécheurs publics notoirement
               infâmes : <quote>« Tous les fidèles<seg type="exquote">, dit le Rituel, de l’Eglise de
                     Paris<note place="margin" resp="author"><quote>« Fideles omnes ad sacram
-                      Communionem admittendi sunt ; exceptis iis qui justa</quote>
-                    <quote>ratione prohibentur. Arcendi autem sunt publice indigni, quales sunt
-                      notorie excommunicati, interdicti, manifesteque infames, ut Meretrices,
-                      Concubinarii, Comœdi, Fœneratores, Magi, Sortilegi, Blasphemi et alii ejus
-                      generis peccatores, nisi de eorum pœnitentia, et emedatione constet, et
-                      publico scandalo prius satisfecerint. »</quote> Rituale Parisiense de
-                    sacramento Eucharistia. pag. 108.</note>,</seg> doivent être admis à la sacrée
-                Communion, excepté ceux auxquels pour quelque juste raison, il est défendu de la
-                recevoir. Et il en faut exclure ceux qui en sont publiquement indignes, tels que
-                sont ceux qui sont notoirement excommuniés, interdits et manifestement infâmes,
-                savoir les femmes débauchées, les Concubinaires, les Comédiens, les Usuriers, les
-                Magiciens, les Sorciers et les Blasphémateurs, et autres semblables pécheurs, si ce
-                n’est qu’il soit constant qu’ils aient fait pénitence de leurs péchés, qu’ils aient
-                donné des preuves de leur amendement, et qu’ils aient auparavant répare le scandale
+                      Communionem admittendi sunt ; exceptis iis qui justa ratione prohibentur.
+                      Arcendi autem sunt publice indigni, quales sunt notorie excommunicati,
+                      interdicti, manifesteque infames, ut Meretrices, Concubinarii, Comœdi,
+                      Fœneratores, Magi, Sortilegi, Blasphemi et alii ejus generis peccatores, nisi
+                      de eorum pœnitentia, et emedatione constet, et publico scandalo prius
+                      satisfecerint. »</quote> Rituale Parisiense de sacramento Eucharistia. pag.
+                    108.</note>,</seg> doivent être admis à la sacrée Communion, excepté ceux
+                auxquels pour quelque juste raison, il est défendu de la recevoir. Et il en faut
+                exclure ceux qui en sont publiquement indignes, tels que sont ceux qui sont
+                notoirement excommuniés, interdits et manifestement infâmes, savoir les femmes
+                débauchées, les Concubinaires, les Comédiens, les Usuriers, les Magiciens, les
+                Sorciers et les Blasphémateurs, et autres semblables pécheurs, si ce n’est qu’il
+                soit constant qu’ils aient fait pénitence de leurs péchés, qu’ils aient donné
+                des preuves de leur amendement, et qu’ils aient auparavant répare le scandale
                 public, par une digne satisfaction. »</quote></p>
             <p>Cet usage perpétuel de l’Eglise détruit entièrement toute la Dissertation. Après cela
               que son Auteur crie tant qu’il voudra : <quote>« L’on jugera si les représentations
@@ -11634,8 +11573,8 @@
           </div>
           <div>
             <head>Dissertation pages 232. et 233. </head>
-            <p>
-              <quote>« Ce qu’il y a de plus tolérable<seg type="exquote">, écrit S. Augustin <note
+
+            <quote><p>« Ce qu’il y a de plus tolérable<seg type="exquote">, écrit S. Augustin <note
                     place="margin" resp="author"><quote>« Et hæc sunt tolerabiliora ludorum, Comœdiæ
                       scilicet, et Tragœdiæ. »</quote> S. Augustin. lib. 2. <hi rend="i">de civit.
                       Dei</hi> cap. 8.</note>,</seg> ce sont les Comédies et les Tragédies, où les
@@ -11644,19 +11583,16 @@
                 beaucoup d’autres jeux du Théâtre : <pb n="244" xml:id="p244"/> elles sont même
                 comptées entre les disciplines libérales, et les jeunes enfants sont ordinairement
                 obligés par des personnes âgées et plus sages qu’eux de les lire et de les apprendre
-                  <note place="margin" resp="author">Confess. lib. 3.</note> .</quote>
-            </p>
-            <p>
-              <quote>« Et se reprochant à lui-même la complaisance qu’il avait eue pour les
-                Spectacles des Théâtres, il ne parle que de la compassion qu’il avait pour les
-                misérables que l’on représentait dans les Tragédies, et de laquelle il faisait alors
-                son plaisir ; disant qu’il était fâché lorsqu’il en sortait sans être ému de
-                douleur, et qu’il entrait dans les intérêts des amants, étant bien aise quand ils
-                obtenaient ce qu’ils avaient désiré. Mais lorsqu’il condamne quelques désordres dans
-                les représentations Théâtrales, il parle de celles qui étaient accompagnées de
-                danses honteuses et de gestes impudents, c’est-à-dire celles des
-                Histrions. »</quote>
-            </p>
+                  <note place="margin" resp="author">Confess. lib. 3.</note>. </p>
+              <p>Et se reprochant à lui-même la complaisance qu’il avait eue pour les Spectacles des
+                Théâtres, il ne parle que de la compassion qu’il avait pour les misérables que l’on
+                représentait dans les Tragédies, et de laquelle il faisait alors son plaisir ;
+                disant qu’il était fâché lorsqu’il en sortait sans être ému de douleur, et qu’il
+                entrait dans les intérêts des amants, étant bien aise quand ils obtenaient ce qu’ils
+                avaient désiré. Mais lorsqu’il condamne quelques désordres dans les représentations
+                Théâtrales, il parle de celles qui étaient accompagnées de danses honteuses et de
+                gestes impudents, c’est-à-dire celles des Histrions. »</p></quote>
+
           </div>
           <div>
             <head>IV. Réfutation.</head>
@@ -11849,8 +11785,8 @@
               instruction qu’il condamne expressément dans le 1. livre de ses <hi rend="i"
                 >Confessions</hi>, où il demande pardon à Dieu des fautes qu’il a commises dans ces
               sortes de lectures qu’il était obligé de faire en son enfance.</p>
-            <p>
-              <quote>« Malheur à toi<seg type="exquote">, dit-il <note place="margin" resp="author"
+
+            <quote><p>« Malheur à toi<seg type="exquote">, dit-il <note place="margin" resp="author"
                       ><quote>« Væ tibi flumen moris humani, quis resistet tibi ? Quandiu non
                       siccaberis ? Quousque volves Evæ filios in mare magnum, et formidosum, quod
                       vix transeunt qui lignum conscenderint ? Nonne ego in te legi et tonantem
@@ -11901,11 +11837,9 @@
                 qu’il les inventait afin qu’attribuant aux Dieux des actions criminelles, elles ne
                 passassent plus pour des crimes, et que ceux qui les commettraient à l’avenir
                 semblassent imiter plutôt les Dieux célestes, et tout puissants, que des hommes
-                perdus, et des scélérats.</quote>
-            </p>
-            <p>
-              <quote>« Et néanmoins, ô fleuve infernal, les hommes ne laissent pas de se plonger
-                avec plaisir dans tes eaux si sales, et si corrompues ; et ils donnent même des
+                perdus, et des scélérats. </p>
+              <p>Et néanmoins, ô fleuve infernal, les hommes ne laissent pas de se plonger avec
+                plaisir dans tes eaux si sales, et si corrompues ; et ils donnent même des
                 récompenses à ceux qui leur apprennent ces folies si dangereuses. On les met en
                 honneur et en crédit, comme des choses grandes, et importantes : et on les enseigne
                 publiquement à la vue des Magistrats, qui ordonnent des gages à ces Professeurs
@@ -11931,20 +11865,18 @@
                 Ν’est-il pas vrai de dire que cette honteuse description n’était nullement
                 nécessaire pour nous faire apprendre ces paroles avec plus de facilité ? Mais que
                 ces paroles au contraire sont très propres pour faire commettre aux hommes cette
-                infamie détestable avec plus de hardiesse ?</quote>
-            </p>
-            <p>
-              <quote>« Je ne condamne point les paroles que je considère en elles-mêmes comme des
-                vases riches et précieux. Je condamne seulement la corruption du vin qui est enfermé
-                dans ces coupes d’or, que ces Docteurs qui étaient ivres eux-mêmes, nous
-                présentaient, voulant nous enivrer aussi bien qu’eux, et le voulant jusqu’à nous
-                châtier sévèrement si nous refusions d’en boire ; sans qu’il nous fût permis d’en
-                appeler au jugement d’un homme sobre. Cependant, mon Dieu, qui me faites la grâce de
+                infamie détestable avec plus de hardiesse ? </p>
+              <p> Je ne condamne point les paroles que je considère en elles-mêmes comme des vases
+                riches et précieux. Je condamne seulement la corruption du vin qui est enfermé dans
+                ces coupes d’or, que ces Docteurs qui étaient ivres eux-mêmes, nous présentaient,
+                voulant nous enivrer aussi bien qu’eux, et le voulant jusqu’à nous châtier
+                sévèrement si nous refusions d’en boire ; sans qu’il nous fût permis d’en appeler au
+                jugement d’un homme sobre. Cependant, mon Dieu, qui me faites la grâce de
                 reconnaître devant vous les désordres de ma vie passée, sans appréhender la rigueur
                 de votre justice, j’ai appris très volontiers toutes ces folies ; et je les
                 apprenais avec plaisir, misérable que j’étais, et c’était ce qui me faisait passer
-                pour un enfant de grande espérance. »</quote>
-            </p>
+                pour un enfant de grande espérance. »</p></quote>
+
             <p>S. Augustin compare les Maîtres qui faisaient lire, et apprendre aux enfants les
               Comédies, à des personnes ivres, qui voulaient enivrer ces enfants. Et l’Auteur de la
               Dissertation fait dire faussement à S. Augustin, <quote>« que les jeunes enfants sont
@@ -12077,8 +12009,7 @@
                   qui flagitia illa finxerunt, eo magis sententiarum elegantia persuadent, et
                   facilius inhærent audientium memoriæ versus numerosi et ornati. Tragicæ historiæ
                   subjiciunt oculis parricidia, et incesta, et cothurnata scelera
-                  demonstrant. »</quote> Lactanius lib. 6. <quote>institut. divin.</quote> cap.
-                20.</note>.</p>
+                  demonstrant. »</quote> Lactanius lib. 6. institut. divin. cap. 20.</note>.</p>
             <p>
               <quote>« Je ne sais s’il y a moins de corruption et de dérèglement dans les Théâtres,
                 que dans les autres Spectacles. Car on <pb n="255" xml:id="p255"/> représente dans
@@ -12450,37 +12381,33 @@
                 et les partageait en certaines heures. »</quote></p>
             <p>Je ne dois pas aussi omettre les lois qu’Aristote veut qu’un sage Législateur
               établisse touchant ce qu’on doit permettre aux enfants de dire, d’écouter, de lire et
-              de voir. <quote>« Que le Législateur<seg type="exquote">, dit-il<note place="margin"
-                    resp="author"><p><quote>« Omnis igitur obscœnitas verborum ut et quidquam aliud
+              de voir. </p>
+            <quote><p>« Que le Législateur<seg type="exquote">, dit-il<note place="margin"
+                    resp="author"><quote><p>« Omnis igitur obscœnitas verborum ut et quidquam aliud
                         per legislatorem exterminanda est de civitate : ex turpiter enim loquendi
                         licentia, sequitur et turpiter facere. Potissimum igitur statim a pueris nec
-                        dicant, nec audiant quidquam turpe.</quote></p><p><quote>« Cum vero dicere
-                        quidquam turpe interdixerimus, clarum est quia et aspicere aut picturas, aut
-                        actus turpes prohibemus. Sit ergo cura magistratibus nullam neque picturam,
-                        neque statuam esse talium rerum imitatricem.</quote></p><p><quote>« Juniores
-                        autem neque jamborum, neque Comœdiarum spectatores esse sinat Legislator :
-                        Omnia enim prima nos magis delectant. Quapropter oportet a pueris omnia
-                        turpia procul removere, et maxime quæcumque habent in se obscœnitatem, vel
-                        improbitatem. »</quote> Aristoteles lib. 7. <hi rend="i">Politic</hi>. cap.
-                      17.</p></note>,</seg> ait soin sur toutes choses de bannir de la ville toutes
-                sortes de paroles sales et déshonnêtes ; car des paroles licencieuses et
+                        dicant, nec audiant quidquam turpe.</p><p>Cum vero dicere quidquam turpe
+                        interdixerimus, clarum est quia et aspicere aut picturas, aut actus turpes
+                        prohibemus. Sit ergo cura magistratibus nullam neque picturam, neque statuam
+                        esse talium rerum imitatricem.</p><p>Juniores autem neque jamborum, neque
+                        Comœdiarum spectatores esse sinat Legislator : Omnia enim prima nos magis
+                        delectant. Quapropter oportet a pueris omnia turpia procul removere, et
+                        maxime quæcumque habent in se obscœnitatem, vel
+                      improbitatem. »</p></quote><p> Aristoteles lib. 7. <hi rend="i">Politic</hi>.
+                      cap. 17.</p></note>,</seg> ait soin sur toutes choses de bannir de la ville
+                toutes sortes de paroles sales et déshonnêtes ; car des paroles licencieuses et
                 déshonnêtes, on passe d’ordinaire aux actions honteuses ; il faut donc accoutumer
                 principalement les enfants dès leur bas âge, à ne rien dire et à ne rien écouter de
-                déshonnête.</quote></p>
-            <p>
-              <quote>« Or ayant défendu de dire aucune parole déshonnête, il est manifeste que nous
-                défendons aussi de regarder des peintures ou des actions déshonnêtes : Que les
-                Magistrats prennent donc garde qu’il n’y ait point de peintures ni de statues qui
-                représentent des choses honteuses.</quote>
-            </p>
-            <p>
-              <pb n="265" xml:id="p265"/>
-              <quote>« Que le Législateur ne souffre point que les enfants soient Spectateurs des
-                Comédies ni des Tragédies, car les premières impressions sont d’ordinaire les plus
-                fortes et les plus agréables : c’est pourquoi il faut éloigner des enfants tout ce
-                qui est déshonnête, et principalement ce qui est en soi honteux ou
-                mauvais. »</quote>
-            </p>
+                déshonnête.</p><p>Or ayant défendu de dire aucune parole déshonnête, il est
+                manifeste que nous défendons aussi de regarder des peintures ou des actions
+                déshonnêtes : Que les Magistrats prennent donc garde qu’il n’y ait point de
+                peintures ni de statues qui représentent des choses honteuses.<pb n="265"
+                  xml:id="p265"/></p><p>Que le Législateur ne souffre point que les enfants soient
+                Spectateurs des Comédies ni des Tragédies, car les premières impressions sont
+                d’ordinaire les plus fortes et les plus agréables : c’est pourquoi il faut éloigner
+                des enfants tout ce qui est déshonnête, et principalement ce qui est en soi honteux
+                ou mauvais. »</p></quote>
+
             <p>De ce que je viens de rapporter je tire deux arguments qui détruisent entièrement
               tout ce que l’Auteur de la Dissertation avance en cet endroit ; premièrement Aristote
               nous apprend qu’à cause qu’il est défendu de dire et d’écouter aucune parole
@@ -12758,42 +12685,37 @@
               modestes et honnêtes, puisqu’il parle en termes exprès des Comédies et des Tragédies
               de l’antiquité, qu’il dit être encore vénérables parmi nous et dignes d’occuper les
               plus beaux esprits, dont les Pères font un jugement tout à fait opposé à celui de
-              l’Auteur de la Dissertation : <quote>« Je ne sais<seg type="exquote">, dit
-                    Lactance<note place="margin" resp="author"><p><quote>« In Scenis nescio an sit
-                        corruptela vitiosior : Nam et Comicæ fabulæ de stupris virginum loquuntur,
-                        aut amoribus meretricum. Et quo magis sunt eloquentes, qui flagitia illa
-                        finxerunt, eo magis sententiarum elegantia persuadent, et facilius inhærent
-                        audientium memoriæ versus numerosi et ornati. Tragicæ historiæ subjiciunt
-                        oculis parricidia, et incesta, et cothurnata scelera
-                      demonstrant.</quote></p><p><quote>« Spectacula hæc publica quoniam maxima sunt
-                        irritamenta vitiorum, et ad corrumpendos animos potentissime valent,
-                        tollenda sunt nobis, quia non modo ad beatam vitam nihil conferunt, sed
-                        etiam nocent plurimum. »</quote> Lactantius lib. 6. <hi rend="i">instit.
-                        divin</hi>. cap. 20.</p></note>,</seg> s’il y a moins de corruption et de
-                dérèglement dans les Théâtres que dans les autres Spectacles ; car on représente
-                dans les Comédies l’incontinence des filles, et les amours des femmes de mauvaise
-                vie. Et plus les Auteurs des fictions de ces crimes infâmes ont d’éloquence, plus
-                ils persuadent ceux qui les <pb n="273" xml:id="p273"/>écoutent par la politesse de
-                leurs sentiments, la justesse et la beauté de leurs vers faisant qu’on les retient
-                plus aisément. Dans les Tragédies l’on expose avec un discours et une action
-                magnifique aux yeux du peuple, les parricides, les incestes et toutes sortes de
-                crimes...</quote></p>
-            <p>
-              <quote>« Nous devons rejeter ces spectacles publics, parce qu’ayant de très puissants
-                attraits pour les vices, et une extrême force pour corrompre les mœurs, ils sont non
-                seulement inutiles pour nous conduire à la vie bienheureuse ; mais ils sont même
-                extrêmement nuisibles. »</quote>
-            </p>
-            <p>
-              <quote>« Ne savez-vous pas <seg type="exquote">, dit S. Chrysostome <note
-                    place="margin" resp="author"><quote>« An ignoratis procliviores nos esse ad
-                      vitia ? Cum igitur et etiam arte et studio ad ea curramus, quomodo fornacem
-                      æterni ignis fugiemus ? »</quote> S. Chrisostom. hom. 38. ad cap. 11. S.
-                    Math.</note>, </seg> quelle pente nous avons au mal ? Lors donc qu’à cette
-                inclination naturelle nous ajoutons encore l’art et l’étude, comment ne
-                tomberons-nous pas dans l’enfer, puisque nous nous hâtons de nous y
-                jeter ? »</quote>
-            </p>
+              l’Auteur de la Dissertation : </p>
+            <quote><p>« Je ne sais<seg type="exquote">, dit Lactance<note place="margin"
+                    resp="author"><quote><p>« In Scenis nescio an sit corruptela vitiosior : Nam et
+                        Comicæ fabulæ de stupris virginum loquuntur, aut amoribus meretricum. Et quo
+                        magis sunt eloquentes, qui flagitia illa finxerunt, eo magis sententiarum
+                        elegantia persuadent, et facilius inhærent audientium memoriæ versus
+                        numerosi et ornati. Tragicæ historiæ subjiciunt oculis parricidia, et
+                        incesta, et cothurnata scelera demonstrant.</p><p>Spectacula hæc publica
+                        quoniam maxima sunt irritamenta vitiorum, et ad corrumpendos animos
+                        potentissime valent, tollenda sunt nobis, quia non modo ad beatam vitam
+                        nihil conferunt, sed etiam nocent plurimum. »</p></quote><p> Lactantius lib.
+                      6. <hi rend="i">instit. divin</hi>. cap. 20.</p></note>,</seg> s’il y a moins
+                de corruption et de dérèglement dans les Théâtres que dans les autres Spectacles ;
+                car on représente dans les Comédies l’incontinence des filles, et les amours des
+                femmes de mauvaise vie. Et plus les Auteurs des fictions de ces crimes infâmes ont
+                d’éloquence, plus ils persuadent ceux qui les <pb n="273" xml:id="p273"/>écoutent
+                par la politesse de leurs sentiments, la justesse et la beauté de leurs vers faisant
+                qu’on les retient plus aisément. Dans les Tragédies l’on expose avec un discours et
+                une action magnifique aux yeux du peuple, les parricides, les incestes et toutes
+                sortes de crimes... </p><p>Nous devons rejeter ces spectacles publics, parce
+                qu’ayant de très puissants attraits pour les vices, et une extrême force pour
+                corrompre les mœurs, ils sont non seulement inutiles pour nous conduire à la vie
+                bienheureuse ; mais ils sont même extrêmement nuisibles. </p><p>Ne savez-vous pas
+                  <seg type="exquote">, dit S. Chrysostome <note place="margin" resp="author"
+                      ><quote>« An ignoratis procliviores nos esse ad vitia ? Cum igitur et etiam
+                      arte et studio ad ea curramus, quomodo fornacem æterni ignis
+                      fugiemus ? »</quote> S. Chrisostom. hom. 38. ad cap. 11. S. Math.</note>,
+                </seg> quelle pente nous avons au mal ? Lors donc qu’à cette inclination naturelle
+                nous ajoutons encore l’art et l’étude, comment ne tomberons-nous pas dans l’enfer,
+                puisque nous nous hâtons de nous y jeter ? »</p></quote>
+
             <p>D’ailleurs quelque honnête que puisse être une Comédie, plus elle est ingénieuse, et
               éloquente, plus elle est dangereuse, parce qu’elle corrompt davantage la vertu, en ce
               qu’elle porte les hommes à ne l’aimer qu’autant qu’ils y trouvent leur plaisir, et
@@ -12881,16 +12803,14 @@
                 les auditeurs soient excités à les imiter, à les honorer et à les
               invoquer »</quote>.</p>
             <p>Ne devait-il pas savoir que ceux qui pour le gain représentent sur le Théâtre les
-              histoires des saints, ne laissent pas pour cela d’être infâmes. <quote>« Celui<seg
-                  type="exquote">, dit un célèbre Jurisconsulte<note place="margin" resp="author"
-                      ><quote>« Qui de Christo, vel Martyre Tragœdiam hodie agit, non notatur nisi
-                      forte ob quæstum prodeat in Scenam. »</quote> Baro. l. 2. de infam.</note>,
-                </seg> qui représente une Tragédie de Jésus-Christ ou d’un Martyr, n’est pas
-                maintenant noté d’infamie, si ce n’est qu’il monte sur le Théâtre pour le
-                gain. »</quote></p>
-            <p>
-              <quote>« Supposez <seg type="exquote">, dit Mariana Jésuite <note place="margin"
-                    resp="author">
+              histoires des saints, ne laissent pas pour cela d’être infâmes. </p>
+            <quote><p>« Celui<seg type="exquote">, dit un célèbre Jurisconsulte<note place="margin"
+                    resp="author"><quote>« Qui de Christo, vel Martyre Tragœdiam hodie agit, non
+                      notatur nisi forte ob quæstum prodeat in Scenam. »</quote> Baro. l. 2. de
+                    infam.</note>, </seg> qui représente une Tragédie de Jésus-Christ ou d’un
+                Martyr, n’est pas maintenant noté d’infamie, si ce n’est qu’il monte sur le Théâtre
+                pour le gain.</p><p>Supposez <seg type="exquote">, dit Mariana Jésuite <note
+                    place="margin" resp="author">
                     <p>
                       <quote>« Fac quod numquam accidisse probabis, Histriones severa aliqua lege
                         constrictos, intra modestiæ fines contineri posse, ac sacras tantum
@@ -12929,24 +12849,20 @@
                 impudique représente la Vierge Marie, ou sainte Catherine ; et qu’un homme infâme
                 représente S. Augustin ou S. Antoine ? C’est ce qu’Arnobe et Tertullien avant lui
                 reprochaient aux Païens de leur temps, de permettre que des hommes vicieux et
-                infâmes représentassent les plus saints de leurs Dieux sur le Théâtre. </quote>
-            </p>
-            <p>
-              <pb n="276" xml:id="p276"/>
-              <quote>« <quote>« N’est-ce pas <seg type="exquote">, dit Tertullien,</seg> quelque
-                  infâme qui se masque du visage de votre Dieu ? n’est-ce pas quelque vicieux qui
-                  paraît sur la Scène, avec un port lascif et une voix efféminée pour contrefaire
-                  une Minerve ou un Hercule ? Dites-moi, si quand vous approuvez ces sacrilèges par
-                  les louanges et les applaudissements que vous leur donnez, vous ne violez pas la
-                  majesté des Dieux, et vous ne profanez pas la Divinité ? »</quote> Vous pouvez
-                appliquer ces paroles à ce qui se fait parmi nous, jugeant bien que ce reproche des
-                anciens tombe sur la licence et sur l’infamie des représentations de notre temps.
-                C’est pourquoi s’il en fallait faire le choix, j’aimerais mieux que les Comédiens
-                représentassent des fables profanes, que des histoires sacrées ; parce que je suis
-                persuadé qu’ils ne les sauraient représenter avec la décence et l’honnêteté qu’elles
-                demandent, tant à cause de l’infamie de leurs personnes, que de la corruption et du
-                dérèglement de leur vie et de leurs mœurs. »</quote>
-            </p>
+                infâmes représentassent les plus saints de leurs Dieux sur le Théâtre.<pb n="276"
+                  xml:id="p276"/></p><p>N’est-ce pas <seg type="exquote">, dit Tertullien,</seg>
+                quelque infâme qui se masque du visage de votre Dieu ? n’est-ce pas quelque vicieux
+                qui paraît sur la Scène, avec un port lascif et une voix efféminée pour contrefaire
+                une Minerve ou un Hercule ? Dites-moi, si quand vous approuvez ces sacrilèges par
+                les louanges et les applaudissements que vous leur donnez, vous ne violez pas la
+                majesté des Dieux, et vous ne profanez pas la Divinité ? »</p></quote>
+            <p>Vous pouvez appliquer ces paroles à ce qui se fait parmi nous, jugeant bien que ce
+              reproche des anciens tombe sur la licence et sur l’infamie des représentations de
+              notre temps. C’est pourquoi s’il en fallait faire le choix, j’aimerais mieux que les
+              Comédiens représentassent des fables profanes, que des histoires sacrées ; parce que
+              je suis persuadé qu’ils ne les sauraient représenter avec la décence et l’honnêteté
+              qu’elles demandent, tant à cause de l’infamie de leurs personnes, que de la corruption
+              et du dérèglement de leur vie et de leurs mœurs. </p>
             <p>En effet comme la fin de la Comédie, est de plaire au gens du monde, il faut que la
               dévotion de ces Saints du Théâtre soit toujours un peu galante : et le diable se sert
               de cette galanterie pour faire perdre l’idée de la générosité et de la charité
@@ -12954,26 +12870,26 @@
               l’éclat de l’amour profane pour en donner de l’estime et pour en exciter les flammes
               dans les cœurs des spectateurs. <quote>« Représenter de bonnes choses<seg
                   type="exquote">, dit le P. Pierre de Guzman Jésuite<note place="margin"
-                    resp="author"><p>
-                      <quote>« El representar se algunas vezes cosas buenas, es assi que se
+                    resp="author">
+                    <quote><p>« El representar se algunas vezes cosas buenas, es assi que se
                         representan. Pero entiendo yo que aun este es artificio del demonio, y delos
                         que ayudan à sus intentos, que por authorisar lo malo, lo juntan, à lo
                         bueno. El mal no tiene fuerça para valer se y tener se por si ; pero
                         arrimado al bien se sabe conservar mejor : <quote>« Venena non dantur nisi
                           mellecircumlita ; et vitia non decipiunt, nisi sub specie, umbraque
-                          virtutum »</quote> Hieron. ad Latam…</quote></p><p><quote>« Que importa
-                        que la Comedia sea buena, si el entremes, si la razon, si la accion, si el
-                        bayle, si la palabra, que se attreviessa, no es buena ? Saben muy bien estos
-                        artifices como quien tiene tambien tomado el pulso al gusto del pueblo que
-                        si la Comedia no lleva alguna cosa ò palabra lasciva, ò torpe, algun
-                        entremes, dança à bayle, que sirva como de salsa ò picante, todo lo demas no
-                        da tanto gusto, ni se lo corre tan bien la ganancia ; y por poco malo que
-                        aya, se estraga lo bueno, porque <quote>« bonum ex integra causa, malum ex
-                          singulari defectu »</quote>…Las cosas santas han se de tratar santamente,
-                        y por personas tales (destas ay pocas entre representantes) no sea que diga
-                        Dios à un pecador de estos, Para que tu te metes en contar mis obras iustas,
-                        y tomar en tu boca mi testamento ? » Psal. 49. v. 17.</quote> P. Pedro de
-                        Guzman<hi rend="i"> de los bienes del honesto trabaio</hi>discurso sexto §.
+                          virtutum »</quote> Hieron. ad Latam…</p><p>Que importa que la Comedia sea
+                        buena, si el entremes, si la razon, si la accion, si el bayle, si la
+                        palabra, que se attreviessa, no es buena ? Saben muy bien estos artifices
+                        como quien tiene tambien tomado el pulso al gusto del pueblo que si la
+                        Comedia no lleva alguna cosa ò palabra lasciva, ò torpe, algun entremes,
+                        dança à bayle, que sirva como de salsa ò picante, todo lo demas no da tanto
+                        gusto, ni se lo corre tan bien la ganancia ; y por poco malo que aya, se
+                        estraga lo bueno, porque <quote>« bonum ex integra causa, malum ex singulari
+                          defectu »</quote>…Las cosas santas han se de tratar santamente, y por
+                        personas tales (destas ay pocas entre representantes) no sea que diga Dios à
+                        un pecador de estos, Para que tu te metes en contar mis obras iustas, y
+                        tomar en tu boca mi testamento ? » Psal. 49. v. 17.</p></quote><p> P. Pedro
+                      de Guzman<hi rend="i"> de los bienes del honesto trabaio</hi>discurso sexto §.
                       8.</p></note>, </seg> est une action dont on doit juger selon la manière
                 qu’elles sont représentées. Néanmoins j’estime que c’est un artifice du démon et de
                 ceux qui l’aident dans l’exécution de ses desseins, de joindre le mal avec le bien,
@@ -12993,7 +12909,7 @@
                 choses saintes se doivent traiter saintement, et par des personnes saintes, dont il
                 y en a peu parmi les Comédiens ; n’est-ce pas ce que Dieu dit à un de ces pécheurs,
                 Ps. 49. v. 27. <quote>« Pourquoi annoncez-vous mes actions justes ; et pourquoi
-                  parlez-vous de mon alliance. »  »</quote> </quote></p>
+                  parlez-vous de mon alliance. » </quote> »</quote></p>
           </div>
           <div>
             <head>Dissertation pag. 237.</head>
@@ -13096,7 +13012,7 @@
               prononcer, non pas de la manière qu’on les récitait sur le Théâtre, mais selon l’usage
               du Barreau et selon qu’il est convenable à des personnes d’honnête condition.
                 <quote>« Il faut<seg type="exquote">, dit Quintilien<note place="margin"
-                    resp="author"><p><quote>« Dandum aliquid Comœdo quoque, dum eatenus, qua
+                    resp="author"><quote><p>« Dandum aliquid Comœdo quoque, dum eatenus, qua
                         pronunciandi scientiam futurus Orator desiderat. Non enim puerum, quem in
                         hoc instituimus, aut fœmineæ vocis exilitate frangi volo, aut seniliter
                         tremere. Nec vitia ebrietatis effingat, nec servili vernilitate imbuatur,
@@ -13106,19 +13022,19 @@
                         ac motus a Comœdis petendus est. Quamquam enim utrumque eorum ad quemdam
                         modum præstare debet Orator. Plurimum tamen aberit a scenico, nec vultu, nec
                         manu, nec excursionibus nimius. Nam si qua in his ars est discentium, ea
-                        prima est, ne ars videatur…</quote></p><p><quote>« Debet etiam docere
-                        Comœdus quomodo narrandum, qua sit auctoritate suadendum : qua concitatione
-                        consurgat ira, qui fletus deceat miserationem. Quod ita optime faciet, si
-                        certos ex Comœdiis elegerit locos, ad hoc maxime idoneos, id est, actionibus
-                        similes. Iidem autem non ad pronuntiandum modo utilissimi, verum ad augendum
-                        quoque eloquentiam maxime accomodati erunt. Et hæc dum infirma ætas majora
-                        non capiet. Cæterum cum legere orationes oportebit, cum virtutes earum jam
+                        prima est, ne ars videatur…</p><p>Debet etiam docere Comœdus quomodo
+                        narrandum, qua sit auctoritate suadendum : qua concitatione consurgat ira,
+                        qui fletus deceat miserationem. Quod ita optime faciet, si certos ex
+                        Comœdiis elegerit locos, ad hoc maxime idoneos, id est, actionibus similes.
+                        Iidem autem non ad pronuntiandum modo utilissimi, verum ad augendum quoque
+                        eloquentiam maxime accomodati erunt. Et hæc dum infirma ætas majora non
+                        capiet. Cæterum cum legere orationes oportebit, cum virtutes earum jam
                         sentiet, tum mihi diligens aliquis, ac peritus assistat : neque solum
                         lectione formet, verum etiam ediscere electa ex his cogat, et ea dicere
                         stantem clare, et quemadmodum agere oportebit, ut protinus pronuntatione
-                        vocem et memoriam exerceat. »</quote> Quintilian. lib. 1. <hi rend="i"
-                        >Institut. Orator.</hi> cap. 11.</p></note>,</seg> apprendre quelque chose
-                des Comédiens, en ce qui regarde la prononciation, dont celui qui prétend être
+                        vocem et memoriam exerceat. »</p></quote><p> Quintilian. lib. 1. <hi
+                        rend="i">Institut. Orator.</hi> cap. 11.</p></note>,</seg> apprendre quelque
+                chose des Comédiens, en ce qui regarde la prononciation, dont celui qui prétend être
                 Orateur a besoin d’être instruit ; car je ne veux pas que l’enfant que j’instruis,
                 déguise sa voix en celle de femme, ou la rende tremblante comme celle des
                 vieillards, je ne veux point aussi qu’il contrefasse les vices des ivrognes ni le
@@ -13131,7 +13047,7 @@
                 être fort différents de ceux des Acteurs de la Scène, il faut que dans le mouvement
                 de son visage et dans les gestes de ses mains, et dans ses digressions, il n’y ait
                 rien qui ne soit modéré ; car s’il y a quelque art à observer en ces choses, c’est
-                de prendre garde qu’il n’y paraisse rien d’artificiel...</quote></p>
+                de prendre garde qu’il n’y paraisse rien d’artificiel... »</quote></p>
             <p>
               <quote>« Le Comédien doit encore enseigner comment il faut faire une narration, avec
                 quelle autorité il faut persuader, avec quel mouvement il faut exciter la colère ;
@@ -13366,26 +13282,22 @@
           </div>
           <div>
             <head>Dissertation pages 238. et 239.</head>
-            <p>
-              <quote>« Si donc il est arrivé que le libertinage des Acteurs ait donné quelque peine
+
+            <quote><p>« Si donc il est arrivé que le libertinage des Acteurs ait donné quelque peine
                 à la pudeur des âmes Chrétiennes, il ne faut en cela qu’imiter les Empereurs qui
                 n’ont jamais rien prononcé contre ces représentations, et qui se sont contentés d’en
                 réformer l’abus et d’imposer des peines rigoureuses contre ceux qui par leurs
                 désordres corrompaient l’excellence de cette Poésie et la beauté de sa
                 représentation, il en faut chasser le vice qui se doit faire haïr partout, et
-                conserver un art qui peut plaire.</quote>
-            </p>
-            <p>
-              <quote>« Les femmes avaient accoutumé d’assister aux combats de la Lutte ; mais
-                Auguste ne voulut pas souffrir qu’on exposât à leurs yeux des hommes tout
-                nus</quote>
-              <note place="margin" resp="author">Sueton. in August.</note>
-              <quote>, qui pouvaient offenser les Sages, et flatter la débauche des autres, et remit
-                au lendemain matin le combat des Athlètes, avec défense aux femmes de venir au
-                Théâtre devant onze <pb n="287" xml:id="p287"/> heures. C’est ainsi qu’il en faut
-                user pour les Poèmes dramatiques ; je veux dire, en éloigner tout ce qui peut
-                offenser les oreilles chastes et l’honnêteté de la vie. »</quote>
-            </p>
+                conserver un art qui peut plaire.</p><p>Les femmes avaient accoutumé d’assister aux
+                combats de la Lutte ; mais Auguste ne voulut pas souffrir qu’on exposât à leurs yeux
+                des hommes tout nus <note place="margin" resp="author">Sueton. in August.</note>,
+                qui pouvaient offenser les Sages, et flatter la débauche des autres, et remit au
+                lendemain matin le combat des Athlètes, avec défense aux femmes de venir au Théâtre
+                devant onze <pb n="287" xml:id="p287"/> heures. C’est ainsi qu’il en faut user pour
+                les Poèmes dramatiques ; je veux dire, en éloigner tout ce qui peut offenser les
+                oreilles chastes et l’honnêteté de la vie. »</p></quote>
+
           </div>
           <div>
             <head>V. Réfutation.</head>
@@ -13669,9 +13581,9 @@
                   et homil. de David. et Saul. </note>. Et lorsqu’ils furent rétablis par les
                 Empereurs Arcadius, et Honorius, <pb n="294" xml:id="p294"/> pour rendre ce
                 contentement à leurs Provinces, ils défendirent expressément d’y mêler aucune chose
-                malhonnête, et contraire à la pudeur, et aux bonnes mœurs</quote>
-              <note place="margin" resp="author"><quote>« Clementiæ nostræ placuit ut Majuma, et
-                  c. »</quote> l.11. c. 45. l. 1. cod. Theodos. de Majuma.</note> . » </p>
+                malhonnête, et contraire à la pudeur, et aux bonnes mœurs <note place="margin"
+                  resp="author"><quote>« Clementiæ nostræ placuit ut Majuma, et c. »</quote> l.11.
+                  c. 45. l. 1. cod. Theodos. de Majuma.</note> . »</quote></p>
           </div>
           <div>
             <head>VI. Réfutation.</head>
@@ -13711,37 +13623,30 @@
                     Octob. Constantinopoli, Thedoro V. C. Consule. Ista quidem sanxit Arcadius, haud
                     dubium impulsore Chrysostomo. »</quote> Baron. ad ann. 399.</p></note>, s’il eût
               pris la peine de le consulter.</p>
-            <p>
-              <quote>« Que gagna enfin S. Chrysostome par ses prédications continuelles à temps et à
-                contretemps ? Il obtint une chose très importante, savoir que le spectacle infâme de
-                Majuma fut entièrement abolie ; lequel ayant été auparavant ôté, avait été rétabli
-                depuis trois ans, en sorte que ce qu’il y avait de honteux et de malhonnête, en fut
-                retranché, par un rescrit de l’Empereur qui est inséré dans le Code de Théodose, au
-                titre de Majuma, en ces termes :</quote>
-            </p>
-            <p>
-              <pb n="295" xml:id="p295"/>
-              <quote>Il nous a semblé bon de rendre aux Provinciaux le divertissement des Jeux de
-                Majuma ; en sorte néanmoins qu’on y garde l’honnêteté, et la pudeur que demandent
-                les bonnes mœurs. Donné à Constantinople le 25. du mois d’Avril, sous le quatrième
-                Consulat de l’Empereur Arcadius, et sous le troisième de l’Empereur Honorius, l’an
-                396. »</quote>
-            </p>
-            <p>
-              <quote>« Mais comme les hommes se portent naturellement au mal, de sorte qu’il est
+
+            <quote><p>« Que gagna enfin S. Chrysostome par ses prédications continuelles à temps et
+                à contretemps ? Il obtint une chose très importante, savoir que le spectacle infâme
+                de Majuma fut entièrement abolie ; lequel ayant été auparavant ôté, avait été
+                rétabli depuis trois ans, en sorte que ce qu’il y avait de honteux et de malhonnête,
+                en fut retranché, par un rescrit de l’Empereur qui est inséré dans le Code de
+                Théodose, au titre de Majuma, en ces termes : <pb n="295" xml:id="p295"/>Il nous a
+                semblé bon de rendre aux Provinciaux le divertissement des Jeux de Majuma ; en sorte
+                néanmoins qu’on y garde l’honnêteté, et la pudeur que demandent les bonnes mœurs.
+                Donné à Constantinople le 25. du mois d’Avril, sous le quatrième Consulat de
+                l’Empereur Arcadius, et sous le troisième de l’Empereur Honorius, l’an
+                396.</p><p>Mais comme les hommes se portent naturellement au mal, de sorte qu’il est
                 plus facile de s’abstenir entièrement de la volupté, que lorsqu’on a la liberté d’en
                 jouir, de se contenir dans les bornes que prescrit l’honnêteté. S. Chrysostome fut
                 encore obligé de prêcher contre les ordures qui souillaient de nouveau ces
                 Spectacles, comme auparavant. Et il en obtint enfin l’entière abolition de
                 l’Empereur Arcadius, par un rescrit qui est aussi inséré dans le même titre du Code
-                de Théodose en ces termes :</quote>
-            </p>
-            <p>
-              <quote>« Nous permettons les arts qui servent aux jeux, et aux divertissements, pour
-                ne pas donner, en les restreignant trop, un sujet de tristesse. Mais nous défendons
-                cet honteux et infâme Spectacle, à qui une licence a donné le nom de Majuma. Donné à
-                Constantinople le 2. d’Octobre, sous le Consulat du très illustre Théodore l’an
-                399. »</quote> Arcadius fit cette loi, sans doute à la poursuite de S. Chrysostome. </p>
+                de Théodose en ces termes :</p><p>
+                <quote>« Nous permettons les arts qui servent aux jeux, et aux divertissements, pour
+                  ne pas donner, en les restreignant trop, un sujet de tristesse. Mais nous
+                  défendons cet honteux et infâme Spectacle, à qui une licence a donné le nom de
+                  Majuma. Donné à Constantinople le 2. d’Octobre, sous le Consulat du très illustre
+                  Théodore l’an 399. »</quote></p></quote>
+            <p> Arcadius fit cette loi, sans doute à la poursuite de S. Chrysostome. </p>
             <p>Mais comme Arcadius n’accordait à S. Chrysostome qu’une partie de ce qu’il demandait,
               en permettant les Comédies, et les autres Spectacles en même temps qu’il défendait
               celui de Majuma ; S. Chrysostome ne laissa pas de continuer ses prédications contre
@@ -13758,8 +13663,8 @@
           </div>
           <div>
             <head>Dissertation pag. 240. et 241.</head>
-            <p>
-              <quote>« Il est certain qu’autrefois les Comédies, étaient représentées dans les
+
+            <quote><p>« Il est certain qu’autrefois les Comédies, étaient représentées dans les
                 Eglises, et durant plusieurs années on n’y trouva rien à redire ; mais lorsque les
                 Ecclésiastiques entreprirent d’y paraître avec des masques ; et diverses
                 bouffonneries indignes de la sainteté des lieux, Innocent III. condamna ce désordre,
@@ -13769,14 +13674,12 @@
                     Bouffones, artem ignominiosam »</quote>, et de vit. et honest. Cleric. lib. 3.
                   cap. 15. Extr. de vit. et honest. Cleric. cap. 12.</note> , c’est-à-dire, selon la
                 Glose, l’art des Histrions, et diseurs de mots de gueule, et les prive de Privilège
-                de Cléricature, s’ils y persévèrent durant une année.</quote>
-            </p>
-            <p>
-              <quote>« Voilà, certes, ce qu’il faut faire ; mais c’est aux sages Politiques d’en
-                trouver les moyens. Je n’entreprendrai pas ici de leur donner conseil, et je dirai
-                seulement que si l’on peut mettre le Théâtre à ce point et innocence, et
-                d’honnêteté, il n’aura plus de contradicteurs. »</quote>
-            </p>
+                de Cléricature, s’ils y persévèrent durant une année.</p><p>Voilà, certes, ce qu’il
+                faut faire ; mais c’est aux sages Politiques d’en trouver les moyens. Je
+                n’entreprendrai pas ici de leur donner conseil, et je dirai seulement que si l’on
+                peut mettre le Théâtre à ce point et innocence, et d’honnêteté, il n’aura plus de
+                contradicteurs. »</p></quote>
+
           </div>
           <div>
             <head>VII. Réfutation.</head>
@@ -13982,43 +13885,41 @@
               sérieuses, qui n’ont pour but que la gloire de Dieu ; il dit que ces représentations
               qui sont des jeux, ne sont point permises, en aucune manière ni dans les Eglises, ni
               dans les lieux sacrés : et cela est conforme aux ordonnances du Synode de Paris, et de
-              celui de Sens que nous avons rapportés ci-dessus. <quote>« Il y a un autre Jeu, <seg
-                  type="exquote">dit l’Auteur de cette Somme<note place="margin" resp="author"><p>
-                      <quote>« Est alius ludus qui dicitur humanus qui fit ad recreationem suam, vel
-                        aliorum. Et iste aliquando dicitur theatralis a loco apto ad Theatrandum,
-                        scilicet spectaculandum ; aliquando larvalis, quæ larvæ sunt deformitates
-                        hominum per appositionem colorum, vel rerum, quæ vulgariter dicuntur
-                        Maschera aliquando Histrionalis, in quo quis de persona sua ludum facit.
-                        Alius illorum qui ludunt alle bagatelle, quæ sunt rerum honestarum
-                        demonstrationes…..</quote></p>
-                    <p><quote>« Tales ludi nullo modo possunt fieri in Ecclesia, aut loco sacro, C.
-                        Cum decorem. de vit. et honest. Cleric. et c. Decet de immunit. Eccles. in
-                        6. Unde non excusarem a mortali, qui talem faceret in Ecclesia, nisi foret
-                        quid modicum, cum videatur jure divino prohibitus ibi, Domus mea domus
-                        orationis, vocabitur, Isay. 56. et Math. 21. Demonstrationes vero quæ fiunt
-                        ad honorem Dei, puta Passionnis Christi, et vitæ alicujus sancti, non sunt
-                        prohibitæ ibi fieri, quia non proprie vocantur ludi, ut notatur in dicto
-                        Canone Cum decorem, per Gloss. et Panormit. »</quote> Summa Angelica in V.
-                      ludus, n. 1. et 2.</p></note>,</seg> qu’on appelle humain, qu’on fait pour son
-                divertissement, ou pour celui des autres. Et ce jeu est quelquefois appelé jeu de
-                Théâtre à cause du lieu où il est représenté qui s’appelle Théâtre, parce qu’il est
-                propre pour voir les spectacles. Quelquefois il est appelé une bouffonnerie, où l’on
-                fait un jeu de sa personne : il y en a un autre qu’on appelle un jeu de Bagatelle,
-                où l’on représente des choses honnêtes.</quote></p>
-            <p>
-              <quote>« Tous ces jeux ne peuvent être représentés en aucune manière ni dans les
-                Eglises, ni dans les lieux sacrés, parce que cela est défendu par le Canon <hi
-                  rend="i">Cum decorem de vit. et honest. Cleric</hi> . Et par le Canon <hi rend="i"
-                  >Decet de immunit. Eccles. in 6.</hi> C’est pourquoi je n’exempterais point de
-                péché mortel celui qui représenterait quelqu’un de ces jeux dans l’Eglise (si ce
-                n’est que ce fût peu de chose) parce qu’il semble que cela est défendu par le droit
-                divin. Isai. 56. et Math. 21. <quote>« Ma Maison sera appelée la maison de la
-                  prière. »</quote> Mais il n’est point défendu de représenter par des figures dans
-                l’Eglise à l’honneur de Dieu la Passion de Jésus-Christ, ou la vie de quelque
-                Saint ; parce que ces représentations ne sont point proprement des jeux ; comme la
-                Glose du Canon <hi rend="i">Decorem</hi> et l’Abbé de Palerme l’ont
-                remarqué. »</quote>
-            </p>
+              celui de Sens que nous avons rapportés ci-dessus. </p>
+            <quote><p>« Il y a un autre Jeu, <seg type="exquote">dit l’Auteur de cette Somme<note
+                    place="margin" resp="author">
+                    <quote><p>« Est alius ludus qui dicitur humanus qui fit ad recreationem suam,
+                        vel aliorum. Et iste aliquando dicitur theatralis a loco apto ad
+                        Theatrandum, scilicet spectaculandum ; aliquando larvalis, quæ larvæ sunt
+                        deformitates hominum per appositionem colorum, vel rerum, quæ vulgariter
+                        dicuntur Maschera aliquando Histrionalis, in quo quis de persona sua ludum
+                        facit. Alius illorum qui ludunt alle bagatelle, quæ sunt rerum honestarum
+                        demonstrationes…..</p><p>Tales ludi nullo modo possunt fieri in Ecclesia,
+                        aut loco sacro, C. Cum decorem. de vit. et honest. Cleric. et c. Decet de
+                        immunit. Eccles. in 6. Unde non excusarem a mortali, qui talem faceret in
+                        Ecclesia, nisi foret quid modicum, cum videatur jure divino prohibitus ibi,
+                        Domus mea domus orationis, vocabitur, Isay. 56. et Math. 21. Demonstrationes
+                        vero quæ fiunt ad honorem Dei, puta Passionnis Christi, et vitæ alicujus
+                        sancti, non sunt prohibitæ ibi fieri, quia non proprie vocantur ludi, ut
+                        notatur in dicto Canone Cum decorem, per Gloss. et
+                      Panormit. »</p></quote><p>Summa Angelica in V. ludus, n. 1. et
+                  2.</p></note>,</seg> qu’on appelle humain, qu’on fait pour son divertissement, ou
+                pour celui des autres. Et ce jeu est quelquefois appelé jeu de Théâtre à cause du
+                lieu où il est représenté qui s’appelle Théâtre, parce qu’il est propre pour voir
+                les spectacles. Quelquefois il est appelé une bouffonnerie, où l’on fait un jeu de
+                sa personne : il y en a un autre qu’on appelle un jeu de Bagatelle, où l’on
+                représente des choses honnêtes.</p><p>Tous ces jeux ne peuvent être représentés en
+                aucune manière ni dans les Eglises, ni dans les lieux sacrés, parce que cela est
+                défendu par le Canon <hi rend="i">Cum decorem de vit. et honest. Cleric</hi> . Et
+                par le Canon <hi rend="i">Decet de immunit. Eccles. in 6.</hi> C’est pourquoi je
+                n’exempterais point de péché mortel celui qui représenterait quelqu’un de ces jeux
+                dans l’Eglise (si ce n’est que ce fût peu de chose) parce qu’il semble que cela est
+                défendu par le droit divin. Isai. 56. et Math. 21. <quote>« Ma Maison sera appelée
+                  la maison de la prière. »</quote> Mais il n’est point défendu de représenter par
+                des figures dans l’Eglise à l’honneur de Dieu la Passion de Jésus-Christ, ou la vie
+                de quelque Saint ; parce que ces représentations ne sont point proprement des jeux ;
+                comme la Glose du Canon <hi rend="i">Decorem</hi> et l’Abbé de Palerme l’ont
+                remarqué. »</p></quote>
             <p>C’est donc sans raison que l’Auteur de la Dissertation dit, <quote>« Qu’il est
                 certain qu’autrefois les comédies étaient représentées dans les Eglises ; que durant
                 plusieurs années, <pb n="302" xml:id="p302"/>on n’y trouva rien à redire, et que le
@@ -14199,7 +14100,7 @@
                 ils consulteront l’Evêque. Nous ordonnons aussi qu’on ne représente plus par des
                 Acteurs le martyre et les actions des Saints, mais qu’on en fasse le <pb n="307"
                   xml:id="p307"/>récit si pieusement, que les Auditeurs soient excités à les imiter,
-                à les honorer, et à les invoquer</quote>. » Ce Décret ne doit pas être considéré
+                à les honorer, et à les invoquer. »</quote> Ce Décret ne doit pas être considéré
               seulement comme un règlement d’une Eglise particulière ; mais comme une ordonnance de
               l’Eglise Universelle, puisque ces sortes de représentations par des <hi rend="i"
                 >Acteurs, ont été bannies de tous les lieux sacrés de la Chrétienté.</hi></p>
@@ -14495,36 +14396,35 @@
                 Poèmes Dramatiques, ni leurs Acteurs n’ont point été condamnés. »</quote> Voici la
               Déclaration du Roi.</p>
 
-            <label type="head">DECLARATION DU ROI, <lb/><hi rend="i">Extraite des Registres du
-                Parlement.</hi></label>
-            <p><quote><hi rend="sc">Louis</hi> par la Grâce de Dieu Roi de France et de Navarre, à
-                tous présents, et à venir, Salut. Les continuelles bénédictions qu’il plaît à Dieu
-                répandre sur notre Règne, nous oblige de plus en plus à faire tout ce qui dépend de
-                nous, pour retrancher tous les dérèglements par lesquels il peut être offensé. La
-                crainte que nous avons que les Comédies qui se représentent utilement pour le
-                divertissement des peuples, soient quelquefois accompagnées de représentations peu
-                honnêtes, qui laissent de mauvaises impressions dans les esprits, fait que nous nous
-                sommes résolus de donner les ordres requis pour éviter tels inconvénients. A ces
-                causes nous avons fait, et faisons très expresses inhibitions et défenses à tous
-                Comédiens, de représenter aucunes actions malhonnêtes, ni d’user d’aucunes paroles
-                lascives, ni à double entente, qui puissent blesser l’honnêteté publique : Et <pb
-                  n="318" xml:id="p318"/>ce sur peine d’être déclarés infâmes, et autres peines
-                qu’il y écherra. Enjoignons à nos Juges, chacun en son détroit<note place="bottom"
-                  resp="editor">[NDE] détroit = juridiction.</note>, tenir la main à ce que notre
-                volonté soit religieusement exécutée. Et en cas que lesdits Comédiens contreviennent
-                à notre présente Déclaration, nous voulons que nosdits Juges leur interdisent le
-                Théâtre, selon la qualité de l’action ; sans néanmoins qu’ils puissent ordonner plus
-                grande peine que l’amende, ou le bannissement. Et au cas que lesdits Comédiens
-                règlent tellement les actions du Théâtre, qu’elles soient du tout exemptes
-                d’impureté ; nous voulons que leur exercice, qui peut divertir nos peuples de
-                diverses occupations mauvaises, ne puisse leur être imputé à blâme, ni préjudicier à
-                leur réputation dans le commerce public. Ce que nous faisons afin que le désir
-                qu’ils auront d’éviter le reproche que l’on leur a fait jusqu’ici, leur donne autant
-                de sujet de se contenir dans les termes de leur devoir aux représentations publiques
-                qu’ils feront, que la crainte des peines qui leur seraient inévitables, s’ils
-                contrevenaient à la présente Déclaration. Si donnons en mandement aux Gens de notre
-                Cour de Parlement de Paris, etc. <date>Donné à saint Germain le 6 Avril, l’an de
-                  Grâce 1641.</date></quote></p>
+            <quote><label type="head">DECLARATION DU ROI, <lb/><hi rend="i">Extraite des Registres
+                  du Parlement.</hi></label><p><hi rend="sc">Louis</hi> par la Grâce de Dieu Roi de
+                France et de Navarre, à tous présents, et à venir, Salut. Les continuelles
+                bénédictions qu’il plaît à Dieu répandre sur notre Règne, nous oblige de plus en
+                plus à faire tout ce qui dépend de nous, pour retrancher tous les dérèglements par
+                lesquels il peut être offensé. La crainte que nous avons que les Comédies qui se
+                représentent utilement pour le divertissement des peuples, soient quelquefois
+                accompagnées de représentations peu honnêtes, qui laissent de mauvaises impressions
+                dans les esprits, fait que nous nous sommes résolus de donner les ordres requis pour
+                éviter tels inconvénients. A ces causes nous avons fait, et faisons très expresses
+                inhibitions et défenses à tous Comédiens, de représenter aucunes actions
+                malhonnêtes, ni d’user d’aucunes paroles lascives, ni à double entente, qui puissent
+                blesser l’honnêteté publique : Et <pb n="318" xml:id="p318"/>ce sur peine d’être
+                déclarés infâmes, et autres peines qu’il y écherra. Enjoignons à nos Juges, chacun
+                en son détroit<note place="bottom" resp="editor">[NDE] détroit =
+                juridiction.</note>, tenir la main à ce que notre volonté soit religieusement
+                exécutée. Et en cas que lesdits Comédiens contreviennent à notre présente
+                Déclaration, nous voulons que nosdits Juges leur interdisent le Théâtre, selon la
+                qualité de l’action ; sans néanmoins qu’ils puissent ordonner plus grande peine que
+                l’amende, ou le bannissement. Et au cas que lesdits Comédiens règlent tellement les
+                actions du Théâtre, qu’elles soient du tout exemptes d’impureté ; nous voulons que
+                leur exercice, qui peut divertir nos peuples de diverses occupations mauvaises, ne
+                puisse leur être imputé à blâme, ni préjudicier à leur réputation dans le commerce
+                public. Ce que nous faisons afin que le désir qu’ils auront d’éviter le reproche que
+                l’on leur a fait jusqu’ici, leur donne autant de sujet de se contenir dans les
+                termes de leur devoir aux représentations publiques qu’ils feront, que la crainte
+                des peines qui leur seraient inévitables, s’ils contrevenaient à la présente
+                Déclaration. Si donnons en mandement aux Gens de notre Cour de Parlement de Paris,
+                etc. <date>Donné à saint Germain le 6 Avril, l’an de Grâce 1641.</date></p></quote>
             <p><quote>Registrées, ouï le Procureur Général, pour être exécutées selon leur forme, et
                 teneur. A Paris en Parlement le 14. Avril 1641.</quote></p>
             <p>Il paraît donc par cette Déclaration que les Comédiens ont toujours été notés
@@ -14611,12 +14511,12 @@
               <label type="speaker">JULIE.</label>
               <l>« Si vous étiez secret, je pourrais entreprendre</l>
               <l>De vous mener chez elle, et de vous faire entendre,</l>
-              <l>Mais j’appréhende trop,</l></quote>
-            <quote><label type="speaker">LEANDRE.</label>
+              <l>Mais j’appréhende trop,</l>
+              <label type="speaker">LEANDRE.</label>
               <l><space> </space>Je te jure, et promets</l>
               <l>De tenir ma parole, et n’en parler jamais.</l>
-              <l><pb n="321" xml:id="p321"/>Faisant cela pour moi tu me donnes la vie.</l></quote>
-            <quote><label type="speaker">JULIE.</label>
+              <l><pb n="321" xml:id="p321"/>Faisant cela pour moi tu me donnes la vie.</l>
+              <label type="speaker">JULIE.</label>
               <l>Je puis bien contenter votre amoureuse envie :</l>
               <l>Je crains ; mais je vous veux servir en ce besoin :</l>
               <l>Surtout dissimulez, et me suivez de loin :</l>
@@ -14624,12 +14524,11 @@
               <l>Si son père est sorti.</l>
               <l>Oui j’ai joué mon rôle assez adroitement,</l>
               <l>Léandre m’a suivie, il attend à la porte,</l>
-              <l>Madame entrera-t-il ?</l></quote>
-
-            <quote><label type="speaker">ORAZIE.</label>
+              <l>Madame entrera-t-il ?</l>
+              <label type="speaker">ORAZIE.</label>
               <l><space> </space>Mais que ce soit en sorte</l>
-              <l>Qu’il ne soupçonne pas...</l></quote>
-            <quote><label type="speaker">JULIE.</label>
+              <l>Qu’il ne soupçonne pas...</l>
+              <label type="speaker">JULIE.</label>
               <l><space> </space>Je vous entends fort bien,</l>
               <l>Ai-je si peu d’esprit ? N’ayez crainte de rien,</l>
               <l>Je sais fort bien conduire une amoureuse ruse<note place="margin" resp="author"
@@ -14656,13 +14555,10 @@
               <l>Ne me demandez point cependant de leçons ;</l>
               <l>Ou je me connais mal à voir votre visage,</l>
               <l>Ou vous n’en êtes pas à votre apprentissage.</l>
-              <l>Etes-vous libéral ?</l></quote>
-
-            <pb n="322" xml:id="p322"/>
-            <quote><label type="speaker">DORANTE. </label>
-              <l><space> </space>Je ne suis point avare.</l></quote>
-
-            <quote><label type="speaker">CLITON.</label>
+              <l>Etes-vous libéral ?</l><pb n="322" xml:id="p322"/>
+              <label type="speaker">DORANTE. </label>
+              <l><space> </space>Je ne suis point avare.</l>
+              <label type="speaker">CLITON.</label>
               <l>C’est un secret d’amour, et bien grand, et bien rare ;</l>
               <l>Mais il faut de l’adresse à le bien débiter,</l>
               <l>Autrement on s’y perd, au lieu d’en profiter :</l>
@@ -14683,8 +14579,8 @@
               <l>« La faveur qu’on mérite est toujours achetée,</l>
               <l>L’heur en croît d’autant plus, moins elle est méritée :</l>
               <l>Et le bien où sans peine elle fait parvenir,</l>
-              <l>Par le mérite à peine aurait pu l’obtenir.</l></quote>
-            <quote><label type="speaker">DORANTE.</label>
+              <l>Par le mérite à peine aurait pu l’obtenir.</l>
+              <label type="speaker">DORANTE.</label>
               <l>Un amant a fort peu de quoi se satisfaire</l>
               <l>Des faveurs qu’on lui fait sans dessein de les faire.</l>
               <l>Comme l’intention seule en forme le prix,</l>
@@ -14692,9 +14588,8 @@
               <l>Jugez par là quel bien peut recevoir ma flamme</l>
               <l>D’une main qu’on me donne, en me refusant l’âme.</l>
               <l>Je la tiens, je la touche, et je la touche en vain,</l>
-              <l>Si je ne puis toucher le cœur avec la main.</l></quote>
-
-            <quote><label type="speaker">CLARICE.</label>
+              <l>Si je ne puis toucher le cœur avec la main.</l>
+              <label type="speaker">CLARICE.</label>
               <l>Cette flamme, Monsieur, est pour moi fort nouvelle</l>
               <l>Puisque j’en viens de voir la première étincelle :</l>
               <l>Si votre cœur ainsi s’embrase en un moment,</l>
@@ -14704,13 +14599,10 @@
               <l><pb n="323" xml:id="p323"/>Confessez cependant qu’à tort vous murmurez</l>
               <l>Du mépris de vos feux que j’avais ignorés<note place="margin" resp="author">Acte 1.
                   Scene 2.</note>. »</l>
-            </quote>
-            <quote>
               <label type="speaker">DORANTE.</label>
               <l>« Cependant accordez à mes feux innocents</l>
-              <l>La licence d’aimer des charmes si puissants.</l></quote>
-
-            <quote><label type="speaker">CLARICE.</label>
+              <l>La licence d’aimer des charmes si puissants.</l>
+              <label type="speaker">CLARICE.</label>
               <l>Un cœur qui veut aimer, et qui sait comme on aime,</l>
               <l>N’en demande jamais licence qu’à soi-même<note place="margin" resp="author">Acte 1.
                   Scene 3.</note>. »</l>
@@ -14743,7 +14635,8 @@
               voyons une fille devenir si amoureuse d’un homme qu’elle voit mener en prison, qu’elle
               lui envoie de l’argent, et même son portrait, et qu’elle-même déguisée en servante le
               va visiter dans la prison. Voici la lettre qu’elle lui écrit :</p>
-            <p> «  <quote>Au bruit du monde qui vous conduisait prisonnier, j’ai mis les yeux à la
+            <p>
+              <quote>« Au bruit du monde qui vous conduisait prisonnier, j’ai mis les yeux à la
                 fenêtre, et vous ai trouvé de si bonne mine, que mon cœur est allé dans la même
                 prison que <pb n="324" xml:id="p324"/> vous, et n’en veut point sortir tant que vous
                 y serez. Je ferai mon possible pour vous en tirer au plus tôt. Cependant obligez-moi
@@ -14758,12 +14651,12 @@
               <l>Feins lors pour le ravoir un déplaisir extrême ;</l>
               <l>S’il le rend, s’en est fait : s’il le retient, il m’aime.</l></quote>
             <quote><label type="speaker">LYSE servante.</label>
-              <l>A vous dire le vrai, vous en savez beaucoup.</l></quote>
-            <quote><label type="speaker">MELISSE.</label>
-              <l>L’Amour est un grand maître, il instruit tout d’un coup.</l></quote>
-            <quote><label type="speaker">LYSE.</label>
-              <l>Il vient de vous donner de belles tablatures.</l></quote>
-            <quote><label type="speaker">MELISSE.</label>
+              <l>A vous dire le vrai, vous en savez beaucoup.</l>
+              <label type="speaker">MELISSE.</label>
+              <l>L’Amour est un grand maître, il instruit tout d’un coup.</l>
+              <label type="speaker">LYSE.</label>
+              <l>Il vient de vous donner de belles tablatures.</l>
+              <label type="speaker">MELISSE.</label>
               <l>Viens quérir mon portrait avec des confitures.</l>
               <l>Comme pourra Dorante en user bien, ou mal,</l>
               <l>Nous résoudrons après touchant l’original. »</l>
@@ -14804,13 +14697,11 @@
             <quote>
               <label type="speaker">CLITON.</label>
               <l>« Donc sans plus de langage</l>
-              <l>Tu veux bien m’en donner quelques baisers pour gage.</l></quote>
-
-
-            <quote><label type="speaker">LYSE.</label>
+              <l>Tu veux bien m’en donner quelques baisers pour gage.</l>
+              <label type="speaker">LYSE.</label>
               <l>Pour l’âme et pour le cœur autant que tu voudras ;</l>
-              <l>Mais pour le bout du doigt ne le demande pas...</l></quote>
-            <quote><label type="speaker">CLITON.</label>
+              <l>Mais pour le bout du doigt ne le demande pas...</l>
+              <label type="speaker">CLITON.</label>
               <l>J’ai le goût fort grossier en matière de flamme,</l>
               <l>Je sais que c’est beaucoup d’avoir le cœur et l’âme ;</l>
               <l>Mais je ne sais pas moins qu’on a fort peu de fruit</l>
@@ -14835,11 +14726,9 @@
               <l>Où le Ciel fut témoin de notre ardeur discrète ;</l>
               <l>Ce vertueux amant n’eut jamais le penser</l>
               <l>De faire une action qui me pût offenser.</l>
-            </quote>
-            <quote><label type="speaker">LUCINDE fille du Gouverneur de Gayète. </label>
-              <l>Jusqu’ici vos destins sont bien dignes d’envie.</l></quote>
-
-            <quote><label type="speaker">FLORIDE.</label>
+              <label type="speaker">LUCINDE fille du Gouverneur de Gayète. </label>
+              <l>Jusqu’ici vos destins sont bien dignes d’envie.</l>
+              <label type="speaker">FLORIDE.</label>
               <l>Vous allez voir bientôt un changement de vie.</l>
               <l>Cet unique sujet de mon affection</l>
               <l>N’aspira pas tout seul à ma possession :</l>
@@ -14867,12 +14756,10 @@
               <l>Se rendit sans témoin au jardin de mon père,</l>
               <l>Où j’attendais pour lors mon véritable amant,</l>
               <l>Qui devait près de moi soupirer son tourment :</l>
-              <l><pb n="327" xml:id="p327"/>Il contrefit sa voix qui trompa mon oreille.</l></quote>
-
-            <quote><label type="speaker">LUCINDE.</label>
-              <l>Artifice inouï, trahison sans pareille.</l></quote>
-
-            <quote><label type="speaker">FLORIDE. </label>
+              <l><pb n="327" xml:id="p327"/>Il contrefit sa voix qui trompa mon oreille.</l>
+              <label type="speaker">LUCINDE.</label>
+              <l>Artifice inouï, trahison sans pareille.</l>
+              <label type="speaker">FLORIDE. </label>
               <l>Je vins ouvrir la porte, il entra tout joyeux ;</l>
               <l>Le voile de la nuit avait bandé mes yeux :</l>
               <l>Je ne le connus pas, et dans cette ignorance  </l>
@@ -14902,24 +14789,20 @@
               <l>Il sortit du jardin avecque ces paroles :</l>
               <l>Mes regrets furent vains, et mes plaintes frivoles :</l>
               <l>Je courus après lui, je l’appelai cent fois ;</l>
-              <l>Mais le dépit ferma son oreille à ma voix.</l></quote>
-
-            <quote><label type="speaker">LUCINDE.</label>
-              <l>Je tremble à ce récit d’une frayeur secrète.</l></quote>
-
-            <quote><label type="speaker">FLORIDE.</label>
+              <l>Mais le dépit ferma son oreille à ma voix.</l>
+              <label type="speaker">LUCINDE.</label>
+              <l>Je tremble à ce récit d’une frayeur secrète.</l>
+              <label type="speaker">FLORIDE.</label>
               <l>La colère du Ciel ne fut pas satisfaite.</l>
               <l><pb n="328" xml:id="p328"/>Au bruit de mes soupirs, et des derniers sanglots</l>
               <l>Qu’exhalait en mourant l’auteur de mes travaux,</l>
               <l>Mon père s’éveilla troublé de mille craintes,</l>
               <l>Il reconnut ma voix ayant ouï mes plaintes.</l>
               <l>Alors en s’écriant qu’on me vint assister.</l>
-              <l>Il avança ma perte, au lieu de l’éviter.</l></quote>
-
-            <quote><label type="speaker">LUCINDE.</label>
-              <l>Comment doncque.</l></quote>
-
-            <quote><label type="speaker">FLORIDE.</label>
+              <l>Il avança ma perte, au lieu de l’éviter.</l>
+              <label type="speaker">LUCINDE.</label>
+              <l>Comment doncque.</l>
+              <label type="speaker">FLORIDE.</label>
               <l><space> </space>La honte, ainsi que l’épouvante</l>
               <l>Me fit fuir au logis d’une mienne parente,</l>
               <l>Où j’ai toujours été depuis l’instant fatal</l>
@@ -15015,11 +14898,8 @@
               <l>Me mit d’un état libre, en un rang où je sers ;</l>
               <l>Je délivrai l’objet qui me tenait aux fers ;</l>
               <l>Je rachetai Sophie ; et la prenant pour femme,</l>
-              <l>En délivrant son corps, m’assujettis son âme.</l></quote>
-
-            <pb n="331" xml:id="p331"/>
-
-            <quote><label type="speaker">ERGASTE valet de Lélie.</label>
+              <l>En délivrant son corps, m’assujettis son âme.</l><pb n="331" xml:id="p331"/>
+              <label type="speaker">ERGASTE valet de Lélie.</label>
               <l>Si de ce long récit vous n’abrégez le cours,</l>
               <l>Le jour achèvera plutôt que ce discours.</l>
               <l>Laissez-le-moi finir avec une parole.</l>
@@ -15035,34 +14915,27 @@
               <l>Jugez par ce récit si vraisemblablement</l>
               <l>Votre jaloux soupçon a quelque fondement,</l>
               <l>Et si quoiqu’on propose, il peut souffrir sans peine,</l>
-              <l>La proposition qu’on leur fait d’Eroxène.</l></quote>
-
-            <quote><label type="speaker">ERASTE ami de Lélie, et amant d’Eroxène.</label>
+              <l>La proposition qu’on leur fait d’Eroxène.</l>
+              <label type="speaker">ERASTE ami de Lélie, et amant d’Eroxène.</label>
               <l>Dieu! jamais Comédie, en sa narration</l>
               <l>N’excita tant de joie, et tant d’attention.</l>
               <l>Et l’éclaircissement, qui dissipe ma crainte,</l>
               <l>M’interdit toute excuse, et condamne ma plainte.</l>
               <l>Mais de quelle arme enfin espérez-vous parer</l>
-              <l>L’Hymen.</l></quote>
-
-            <quote><label type="speaker">LELIE.</label>
+              <l>L’Hymen.</l>
+              <label type="speaker">LELIE.</label>
               <l>Nous vous cherchions pour en délibérer</l>
               <l>J’ai fait mon personnage en cette Comédie ;</l>
-              <l>Pour ce qui reste, il faut qu’Ergaste y remédie.</l></quote>
-
-            <quote>
+              <l>Pour ce qui reste, il faut qu’Ergaste y remédie.</l>
               <label type="speaker">ERGASTE.</label>
               <l>J’ai pendant ce récit eu le temps d’y rêver ;</l>
               <l>Voyez si ce moyen se pourrait approuver.</l>
               <l>Au vieillard Polydore Anselme offre Sophie</l>
               <l>Ou plutôt pour ses biens il la lui sacrifie,</l>
-              <l>Voyant qu’il s’est offert de la prendre sans dot.</l></quote>
-
-            <quote><label type="speaker">LELIE</label>
-              <l> Il est vrai.</l></quote>
-
-
-            <quote><label type="speaker">ERGASTE.</label>
+              <l>Voyant qu’il s’est offert de la prendre sans dot.</l>
+              <label type="speaker">LELIE</label>
+              <l> Il est vrai.</l>
+              <label type="speaker">ERGASTE.</label>
               <l><space> </space>Mon avis est, qu’Eraste en un mot</l>
               <l><pb n="332" xml:id="p332"/>Lui faisant la même offre, obtienne sa parole,</l>
               <l>Et rende du vieillard l’espérance frivole.</l>
@@ -15074,41 +14947,31 @@
               <l>Qu’Eroxène causant votre plus doux souci,</l>
               <l>Votre plus grand bonheur est qu’Hymen vous assemble.</l>
               <l>Et lors il est aisé de vous loger ensemble,</l>
-              <l>Et que par cet intrigue adroitement conduit.</l></quote>
-
-
-            <quote><label type="speaker">LELIE.</label>
-              <l> Et bien ?</l></quote>
-
-
-            <quote><label type="speaker">ERGASTE.</label>
+              <l>Et que par cet intrigue adroitement conduit.</l>
+              <label type="speaker">LELIE.</label>
+              <l> Et bien ?</l>
+              <label type="speaker">ERGASTE.</label>
               <l><space> </space> La sœur du jour, soit femme de la nuit,</l>
               <l>Tant que de vos vieillards, qui n’ont plus guère à vivre</l>
-              <l>La mort qui change tout, de ces soins vous délivre.</l></quote>
-
-
-            <quote><label type="speaker">ERASTE.</label>
+              <l>La mort qui change tout, de ces soins vous délivre.</l>
+              <label type="speaker">ERASTE.</label>
               <l>Comment sans épouser posséder leurs appas,</l>
               <l>Ou comment épousant ne les posséder pas ?</l>
               <l>N’est-ce pas te confondre, ou d’un double adultère</l>
-              <l>De ce lien sacré profaner le mystère ?</l></quote>
-
-            <quote><label type="speaker">ERGASTE.</label>
+              <l>De ce lien sacré profaner le mystère ?</l>
+              <label type="speaker">ERGASTE.</label>
               <l>Un ami travesti, vos parents assemblés,</l>
               <l>Vous peut-il pas unir de ces nœuds simulés ?</l>
               <l>Puis leur mort arrivant, un Hymen légitime</l>
-              <l>Des faveurs d’Eroxène effacera le crime.</l></quote>
-
-            <quote><label type="speaker">LELIE.</label>
+              <l>Des faveurs d’Eroxène effacera le crime.</l>
+              <label type="speaker">LELIE.</label>
               <l>Un plus rare moyen ne se peut concevoir :</l>
               <l>Et tu me rends la vie en me rendant l’espoir.</l>
               <l>Par cet heureux avis, qui nous tire de peine,</l>
-              <l>Je conserve Aurélie.</l></quote>
-
-            <quote><label type="speaker">ERASTE.</label>
-              <l><space> </space>Et j’épouse Eroxène.</l></quote>
-
-            <quote><label type="speaker">ERGASTE.</label>
+              <l>Je conserve Aurélie.</l>
+              <label type="speaker">ERASTE.</label>
+              <l><space> </space>Et j’épouse Eroxène.</l>
+              <label type="speaker">ERGASTE.</label>
               <l>Moi peut-être un gibet, si l’art est éventé ;</l>
               <l>Mais n’en consultons plus, le sort en est jeté. »</l>
             </quote>
@@ -15133,44 +14996,32 @@
             <quote>
               <label type="speaker">D. FERNAND.</label>
               <l>« Enfin voulez-vous voir</l>
-              <l>Cet amant si chéri ?</l></quote>
-
-
-            <quote><label type="speaker">LEONOR.</label>
+              <l>Cet amant si chéri ?</l>
+              <label type="speaker">LEONOR.</label>
               <l><space> </space>S’il se peut dès ce soir :</l>
-              <l>De ce désir mon âme est si fort possédée.</l></quote>
-
-            <quote><label type="speaker">D. FERNAND.</label>
+              <l>De ce désir mon âme est si fort possédée.</l>
+              <label type="speaker">D. FERNAND.</label>
               <l>Il me faut faire un pacte avecque son idée ;</l>
               <l>Ce charme est innocent ; mais pour un tel dessein</l>
-              <l>J’ai besoin d’un billet écrit de votre main.</l></quote>
-
-            <quote><label type="speaker">LEONOR.</label>
-              <l>Puis-je rien refuser à ce que je souhaite ?</l></quote>
-
-            <label type="speaker">D. FERNAND.</label>
-            <l>Je le déchirerai ma figure étant faite ;</l>
-            <l>Dépêche, Philippin, de l’encre, et du papier.</l>
-
-            <label type="speaker">LEONOR à Jacinte sa servante</label>
-            <l> Jacinte.</l>
-
-            <label type="speaker">JACINTE.</label>
-            <l><space> </space>Madame il est sorcier,</l>
-            <l>Et si vous écrivez, c’est chose indubitable</l>
-            <l>Qu’il portera soudain votre billet au diable ;</l>
-            <l><pb n="334" xml:id="p334"/>On parlera de vous ce soir dans le sabbat.</l>
-            <l>Je l’en refuserais.</l>
-
-
-            <label type="speaker">LEONOR.</label>
-            <l><space> </space>Ton cœur trop tôt s’abat,</l>
-            <l>Et pour mon intérêt tu te mets trop en peine.</l>
-
-
-            <label type="speaker">D. FERNAND lui présentant la plume. </label>
-            <l>Je m’en vais vous dicter, écrivez...</l>
-            <quote>
+              <l>J’ai besoin d’un billet écrit de votre main.</l>
+              <label type="speaker">LEONOR.</label>
+              <l>Puis-je rien refuser à ce que je souhaite ?</l>
+              <label type="speaker">D. FERNAND.</label>
+              <l>Je le déchirerai ma figure étant faite ;</l>
+              <l>Dépêche, Philippin, de l’encre, et du papier.</l>
+              <label type="speaker">LEONOR à Jacinte sa servante</label>
+              <l> Jacinte.</l>
+              <label type="speaker">JACINTE.</label>
+              <l><space> </space>Madame il est sorcier,</l>
+              <l>Et si vous écrivez, c’est chose indubitable</l>
+              <l>Qu’il portera soudain votre billet au diable ;</l>
+              <l><pb n="334" xml:id="p334"/>On parlera de vous ce soir dans le sabbat.</l>
+              <l>Je l’en refuserais.</l>
+              <label type="speaker">LEONOR.</label>
+              <l><space> </space>Ton cœur trop tôt s’abat,</l>
+              <l>Et pour mon intérêt tu te mets trop en peine.</l>
+              <label type="speaker">D. FERNAND lui présentant la plume. </label>
+              <l>Je m’en vais vous dicter, écrivez...</l>
               <label type="head"> BILLET. </label>
               <l>D. Juan, je sais bien où vous êtes,</l>
               <l>Venez me voir dès cette nuit.</l>
@@ -15396,8 +15247,8 @@
               et la haine violent la loi de la nature, et que la vengeance est un aveu de notre
               ressentiment, et de notre faiblesse ; en un mot, que nous devons être maîtres de nos
               passions.</p>
-            <p>
-              <quote>« Mais la colère est accompagnée de quelque plaisir, et il est doux de rendre
+
+            <quote><p>« Mais la colère est accompagnée de quelque plaisir, et il est doux de rendre
                 le mal qu’on a reçu. Non, <seg type="exquote">dit Sénèque<note place="margin"
                     resp="author"><p>
                       <quote>« At enim ira habet aliquam voluptatem, et dulce est dolorem reddere.
@@ -15435,50 +15286,41 @@
                 appelle vengeance, n’est qu’une inhumanité, qu’on couvre néanmoins du nom de
                 Justice. Et ne diffère point de l’outrage, qu’en ce que celui qui outrage offense le
                 premier, et celui qui se venge ne fait que rendre le mal qu’il a reçu, c’est
-                pourquoi son péché est plus excusable...</quote>
-            </p>
-            <p>
-              <quote>« Toutes les fois que nous aurons peine à pardonner, considérons s’il nous
-                serait avantageux que tout le monde fût inexorable pour nous. Combien de fois celui
-                qui a refusé le pardon, a-t-il été contraint de le demander lui-même ? Combien de
-                fois s’est-il jeté aux pieds de celui qu’il avait repoussé des siens ? Y a-t-il rien
-                de plus glorieux, que changer sa colère en amitié ?</quote>
-            </p>
-            <p>
-              <quote>« Soyons persuadés que les plus sains, et les plus forts mouvements de notre
-                âme, sont ceux qui suivent la règle de notre volonté, et non pas la promptitude de
-                leur impétuosité.</quote>
-            </p>
-            <p>
-              <quote>« Pour ne rien dire des maux qui suivent la colère de près, des embuches, et de
-                l’inquiétude perpétuelle pour les événements des combats particuliers ; elle souffre
-                toujours le châtiment qu’elle fait souffrir aux autres. Elle corrompt la nature
-                même : la nature nous exhorte, et nous inviter à l’amour ; et la colère nous porte à
-                la haine ; la nature nous commande de faire du bien à tous les hommes, et la colère
-                nous pousse à leur nuire. Ajoutez encore que l’indignation procède d’une trop bonne
-                opinion de soi-même ; et qu’elle semble courageuse ; néanmoins elle est toujours
-                basse, et n’a pas le cœur si grand qu’elle le veut faire paraître; car celui qui
-                croit avoir été méprisé de quelqu’un, se reconnaît moindre que lui. Mais un cœur
-                véritablement courageux, et qui se connaît bien soi-même, ne se venge pas des
-                injures, parce qu’il n’en ressent point de mal ; comme les traits qu’on a jetés
-                contre des marbres, retournent contre ceux qui les ont jetés, et comme on ne peut
-                frapper sur ce qui est dur, et solide, qu’on ne se fasse mal à soi-même. Ainsi il
-                n’y a point d’injure qui puisse obliger <pb n="341" xml:id="p341"/> un grand courage
-                d’en avoir du ressentiment, parce qu’elle est trop faible pour offenser celui
-                qu’elle attaque. Combien est-il plus glorieux de mépriser les injures, et les
-                outrages, comme des traits dont on ne peut être blessé ? La vengeance, est un aveu
-                du mal, et de la douleur qu’on ressent. L’esprit que les injures font plier, n’est
-                pas bien fort. Celui qui vous a outragé est-il plus grand, ou moindre que vous ?
-                s’il est moindre ; pardonnez-lui ? S’il est plus grand épargnez-vous vous-même. Il
-                n’y a point de plus grande marque de la grandeur de courage, que de faire paraître
-                qu’il ne peut rien arriver qui soit capable de vous émouvoir.</quote>
-            </p>
-            <p>
-              <quote>« Il ne faut donc pas se laisser emporter à la colère, ni contre un adversaire,
-                qui vous soit égal, ni contre un moindre, ni contre un plus grand que vous. Il y a
-                du danger à combattre contre son égal. C’est une folie de s’en prendre à un plus
-                grand que soi : et il est honteux de se commettre avec un moindre. »</quote>
-            </p>
+                pourquoi son péché est plus excusable...</p><p>Toutes les fois que nous aurons peine
+                à pardonner, considérons s’il nous serait avantageux que tout le monde fût
+                inexorable pour nous. Combien de fois celui qui a refusé le pardon, a-t-il été
+                contraint de le demander lui-même ? Combien de fois s’est-il jeté aux pieds de celui
+                qu’il avait repoussé des siens ? Y a-t-il rien de plus glorieux, que changer sa
+                colère en amitié ?</p><p>Soyons persuadés que les plus sains, et les plus forts
+                mouvements de notre âme, sont ceux qui suivent la règle de notre volonté, et non pas
+                la promptitude de leur impétuosité.</p><p>Pour ne rien dire des maux qui suivent la
+                colère de près, des embuches, et de l’inquiétude perpétuelle pour les événements des
+                combats particuliers ; elle souffre toujours le châtiment qu’elle fait souffrir aux
+                autres. Elle corrompt la nature même : la nature nous exhorte, et nous inviter à
+                l’amour ; et la colère nous porte à la haine ; la nature nous commande de faire du
+                bien à tous les hommes, et la colère nous pousse à leur nuire. Ajoutez encore que
+                l’indignation procède d’une trop bonne opinion de soi-même ; et qu’elle semble
+                courageuse ; néanmoins elle est toujours basse, et n’a pas le cœur si grand qu’elle
+                le veut faire paraître; car celui qui croit avoir été méprisé de quelqu’un, se
+                reconnaît moindre que lui. Mais un cœur véritablement courageux, et qui se connaît
+                bien soi-même, ne se venge pas des injures, parce qu’il n’en ressent point de mal ;
+                comme les traits qu’on a jetés contre des marbres, retournent contre ceux qui les
+                ont jetés, et comme on ne peut frapper sur ce qui est dur, et solide, qu’on ne se
+                fasse mal à soi-même. Ainsi il n’y a point d’injure qui puisse obliger <pb n="341"
+                  xml:id="p341"/> un grand courage d’en avoir du ressentiment, parce qu’elle est
+                trop faible pour offenser celui qu’elle attaque. Combien est-il plus glorieux de
+                mépriser les injures, et les outrages, comme des traits dont on ne peut être
+                blessé ? La vengeance, est un aveu du mal, et de la douleur qu’on ressent. L’esprit
+                que les injures font plier, n’est pas bien fort. Celui qui vous a outragé est-il
+                plus grand, ou moindre que vous ? s’il est moindre ; pardonnez-lui ? S’il est plus
+                grand épargnez-vous vous-même. Il n’y a point de plus grande marque de la grandeur
+                de courage, que de faire paraître qu’il ne peut rien arriver qui soit capable de
+                vous émouvoir.</p><p>Il ne faut donc pas se laisser emporter à la colère, ni contre
+                un adversaire, qui vous soit égal, ni contre un moindre, ni contre un plus grand que
+                vous. Il y a du danger à combattre contre son égal. C’est une folie de s’en prendre
+                à un plus grand que soi : et il est honteux de se commettre avec un
+              moindre. »</p></quote>
+
             <p>La Comédie détruit toutes ces belles maximes de la Philosophie par les dangereux
               exemples qu’elle propose des passions, auxquelles elle donne toute leur étendue sans
               mesure, et sans bornes. Elle représente les transports de colère, de haine, et de
@@ -15500,7 +15342,7 @@
             <p>Et dans la Tragédie de <hi rend="i">Sertorius</hi> Aristie prend sa haine pour un
               devoir d’honneur, et de générosité.</p>
             <quote>
-              <label type="speaker"><pb n="342" xml:id="p342"/>ARISTIE. </label>
+              <pb n="342" xml:id="p342"/><label type="speaker">ARISTIE. </label>
               <l>« Oui, Seigneur, il est vrai que j’ai le cœur sensible,</l>
               <l>Suivant qu’on m’aime, ou hait, j’aime, ou hais à mon tour,</l>
               <l>Et ma gloire soutient ma haine, et mon amour.</l>
@@ -15627,25 +15469,21 @@
           </div>
           <div>
             <head>Dissertation pag. 243. et 244.</head>
-            <p>
-              <quote>« Il y a cinquante ans qu’une honnête femme n’osait aller au Théâtre, ou bien
+
+            <quote><p>« Il y a cinquante ans qu’une honnête femme n’osait aller au Théâtre, ou bien
                 il fallait qu’elle fût voilée, et tout à fait invisible ; et ce plaisir était comme
                 réservé aux débauchées, qui se donnaient la liberté de le regarder à visage
                 découvert. Mais aujourd’hui les femmes d’honneur et de qualité s’y trouvent en foule
                 avec toute liberté, au lieu que celles dont le désordre a signalé la vie, et le nom,
                 n’osent plus y paraître que sous le masque, et dans un déguisement qui les
-                condamne.</quote>
-            </p>
-            <p>
-              <quote>« Il est certain néanmoins que depuis quelques années notre Théâtre se laisse
-                retomber peu à peu dans sa vieille corruption, et que les farces impudentes, et les
-                Comédies libertines, où l’on mêle bien des choses contraires au sentiment de la
-                piété, et aux bonnes mœurs, ranimeront bientôt la justice de nos Rois, et y
-                rappelleront la honte et les châtiments. »</quote>
-            </p>
+                condamne.</p><p>Il est certain néanmoins que depuis quelques années notre Théâtre se
+                laisse retomber peu à peu dans sa vieille corruption, et que les farces impudentes,
+                et les Comédies libertines, où l’on mêle bien des choses contraires au sentiment de
+                la piété, et aux bonnes mœurs, ranimeront bientôt la justice de nos Rois, et y
+                rappelleront la honte et les châtiments. »</p></quote>
+            <pb n="346" xml:id="p346"/>
           </div>
           <div>
-            <pb n="346" xml:id="p346"/>
             <head>X. Réfutation.</head>
             <p>L’Auteur de la Dissertation reconnaît que le Théâtre il y a cinquante ans était si
               peu honnête, qu’une honnête femme n’osait y aller ; et il avoue que depuis quelques
@@ -15958,7 +15796,7 @@
                         no pocos, ny de poca autoridad, y son delos que dize con harto sentimiento
                         un Propheta : <quote>« Va qui dicitis malum, bonum ; et bonum, malum :
                           ponentes tenebras lucem : et lucem, tenebras : ponentes amarum in dulce ;
-                          et dulce in amarum. »</quote> Isay. 5. v. 20. </quote></p>
+                          et dulce in amarum. »</quote> Isay. 5. v. 20. »</quote></p>
                     <p>
                       <quote>« Confunden sin duda las cosas, y trucean los nombres, y cubren con
                         capa de bien, à lo que encubre mil males, y daños, y ciegan se, y quieren
@@ -16001,7 +15839,8 @@
               de l’Auteur de la Dissertation. Mais ils étaient persuadés au contraire, qu’il fallait
               entièrement abolir les représentations des Poèmes Dramatiques que les Comédiens font
               sur le Théâtre ; parce que ces pièces ne pouvaient être innocentes, ni entièrement
-              honnêtes : <quote>« Après avoir considéré<seg type="exquote">, dit le Père Guzman<note
+              honnêtes : </p>
+            <quote><p>« Après avoir considéré<seg type="exquote">, dit le Père Guzman<note
                     place="margin" resp="author"><quote>« Visto pues todo lo dicho, y que con la
                       experiencia de tan largo tiempo no es possible poner medio, ò remedio en esto,
                       ni circunstancionar estas Comedias con las reglas de la razon, excludendo
@@ -16020,73 +15859,63 @@
                 renaissait une autre ; ou comme un bras si gâté de gangrène, qu’il est plus facile
                 et plus salutaire de le couper tout à fait, que d’en retrancher ce qui est pourri,
                 qui en est la plus grande partie ; j’estime qu’il vaut mieux bannir ces Comédies de
-                la République Chrétienne, que de les réformer et de les tolérer. »</quote></p>
-            <p>
-              <quote>« J’estime, <seg type="exquote">dit le Père Mariana <note place="margin"
-                    resp="author"><p>
-                      <quote>« Censeo cum multis, fore e Republica si Histriones pretio venales
+                la République Chrétienne, que de les réformer et de les tolérer.</p><p>J’estime,
+                  <seg type="exquote">dit le Père Mariana <note place="margin" resp="author">
+                    <quote><p>« Censeo cum multis, fore e Republica si Histriones pretio venales
                         penitus removeantur ; omnes enim pecuniæ vias norunt ; et pecuniæ causa
-                        omnes turpitudines siscipiunt, instilantque aliis, et c.</quote></p>
-                    <p><quote>« Itaque si duorum optio danda esset, mallem ab Histrionibus prophanas
-                        fabulas agi, quam sacras historias ; quoniam cum decore et honestate eos
-                        facere non posse persuasum plane habeo, tum ob eorum vilitatem, et dedecus,
-                        tum ob fœdissimos mores, paremque actionum levitatem, et turpitudinem.
-                         »</quote> Mariana <hi rend="i">de Rege et Regis institut</hi> . lib. 3. c.
-                      16.</p>
+                        omnes turpitudines siscipiunt, instilantque aliis, et c.</p><p>Itaque si
+                        duorum optio danda esset, mallem ab Histrionibus prophanas fabulas agi, quam
+                        sacras historias ; quoniam cum decore et honestate eos facere non posse
+                        persuasum plane habeo, tum ob eorum vilitatem, et dedecus, tum ob fœdissimos
+                        mores, paremque actionum levitatem, et turpitudinem.  »</p></quote><p>
+                      Mariana <hi rend="i">de Rege et Regis institut</hi> . lib. 3. c. 16.</p>
                   </note>,</seg> comme font aussi plusieurs autres, qu’il serait utile à l’Etat, que
                 les Comédiens qui ne montent sur le Théâtre que pour le gain, fussent entièrement
                 rejetés : car ils tentent toutes les voies d’où ils peuvent tirer de l’argent : il
                 n’y a point d’impureté dont ils ne se souillent, et qu’ils n’inspirent aux autres
-                pour cet effet, etc.</quote>
-            </p>
-            <p>
-              <quote>« C’est pourquoi, s’il en fallait faire le choix, j’aimerais mieux que les
-                Comédiens représentassent des fables profanes, que des histoires sacrées ; parce que
-                je suis persuadé qu’ils ne les sauraient représenter avec la décence, et l’honnêteté
-                qu’elles demandent, tant à cause de l’infamie de leurs personnes, que de la
-                corruption, et du dérèglement de leur vie, et de leurs mœurs. »</quote>
-            </p>
-            <p>
-              <quote>« Il faut regarder <seg type="exquote">, disent d’autres doctes Chrétiens<note
-                    place="bottom" resp="editor"> [NDE] Les paragraphes qui suivent sont traités
-                    comme une citation mais ne sont pas attribués.</note>,</seg> quelle est la vie
-                d’un Comédien et d’une Comédienne, quelle est la matière, et le but des Comédies, et
-                quels effets elles produisent d’ordinaire dans les esprits de ceux qui les
-                représentent, ou qui les voient représenter, quelles impressions elles leur
+                pour cet effet, etc.</p><p>C’est pourquoi, s’il en fallait faire le choix,
+                j’aimerais mieux que les Comédiens représentassent des fables profanes, que des
+                histoires sacrées ; parce que je suis persuadé qu’ils ne les sauraient représenter
+                avec la décence, et l’honnêteté qu’elles demandent, tant à cause de l’infamie de
+                leurs personnes, que de la corruption, et du dérèglement de leur vie, et de leurs
+                mœurs.</p><p>Il faut regarder <seg type="exquote">, disent d’autres doctes
+                    Chrétiens<note place="bottom" resp="editor"> [NDE] Les paragraphes qui suivent
+                    sont traités comme une citation mais ne sont pas attribués.</note>,</seg> quelle
+                est la vie d’un Comédien et d’une Comédienne, quelle est la matière, et le but des
+                Comédies, et quels effets elles produisent d’ordinaire dans les esprits de ceux qui
+                les représentent, ou qui les voient représenter, quelles impressions elles leur
                 laissent ; et examiner ensuite si tout cela a quelque rapport avec la vie, les
-                sentiments, et les devoirs d’un véritable Chrétien.</quote>
-            </p>
-            <p>
-              <quote>« Il est impossible qu’on considère le métier de Comédien, et qu’on le compare
-                avec la profession Chrétienne, qu’on ne reconnaisse qu’il n’y a rien de plus indigne
-                d’un enfant de Dieu, et d’un membre de Jésus-Christ que cet emploi. On ne parle pas
-                seulement des dérèglements grossiers, et de la manière dissolue dont les femmes y
-                paraissent (parce que ceux qui prétendent justifier la Comédie, en séparent toujours
-                ces sortes de désordres par l’imagination, quoique on ne les sépare jamais
-                effectivement.) On ne parle que de ce qui en est entièrement inséparable, C’est un
-                métier qui a pour but <pb n="357" xml:id="p357"/> le divertissement des autres ; où
-                des hommes et des femmes paraissent sur un Théâtre pour y représenter des passions
-                de haine, de colère, d’ambition, de vengeance, et principalement d’amour. Il faut
-                qu’ils les expriment le plus naturellement, et le plus vivement qu’il leur est
-                possible ; et ils ne le sauraient faire, s’ils ne les excitent en quelque sorte en
-                eux-mêmes, et si leur âme ne prend tous les plis que l’on voit sur le visage. Il
-                faut donc que ceux qui représentent une passion d’amour, en soient en quelque sorte
-                touchés, pendant qu’ils la représentent. Et il ne faut pas s’imaginer que l’on
-                puisse effacer de son esprit cette impression qu’on y a excitée volontairement, et
-                qu’elle ne laisse pas en nous une grande disposition à cette même passion que l’on a
-                bien voulu ressentir. Ainsi la Comédie par sa nature même est une école et un
-                exercice de vice, puisque c’est un art, où il faut nécessairement exciter en
-                soi-même des passions vicieuses. Que si l’on considère que toute la vie des
-                Comédiens est occupée dans cet exercice, qu’ils la passent toute entière à apprendre
-                en particulier, ou à répéter entre eux, ou à représenter devant des spectateurs
-                l’image de quelque vice, qu’ils n’ont presque autre chose dans l’esprit, que ces
-                folies ; on verra facilement qu’il est impossible d’allier ce métier avec la pureté
-                de notre Religion : et ainsi il faut avouer que c’est un métier profane, et indigne
-                d’un Chrétien ; que ceux qui l’exercent, sont obligés de le quitter, comme tous les
-                Conciles le leur ordonnent, et par conséquent qu’il n’est point permis aux autres de
-                contribuer à les entretenir dans une profession contraire au Christianisme, ni de
-                l’autoriser par leur présence. »</quote>
-            </p>
+                sentiments, et les devoirs d’un véritable Chrétien.</p><p>Il est impossible qu’on
+                considère le métier de Comédien, et qu’on le compare avec la profession Chrétienne,
+                qu’on ne reconnaisse qu’il n’y a rien de plus indigne d’un enfant de Dieu, et d’un
+                membre de Jésus-Christ que cet emploi. On ne parle pas seulement des dérèglements
+                grossiers, et de la manière dissolue dont les femmes y paraissent (parce que ceux
+                qui prétendent justifier la Comédie, en séparent toujours ces sortes de désordres
+                par l’imagination, quoique on ne les sépare jamais effectivement.) On ne parle que
+                de ce qui en est entièrement inséparable, C’est un métier qui a pour but <pb n="357"
+                  xml:id="p357"/> le divertissement des autres ; où des hommes et des femmes
+                paraissent sur un Théâtre pour y représenter des passions de haine, de colère,
+                d’ambition, de vengeance, et principalement d’amour. Il faut qu’ils les expriment le
+                plus naturellement, et le plus vivement qu’il leur est possible ; et ils ne le
+                sauraient faire, s’ils ne les excitent en quelque sorte en eux-mêmes, et si leur âme
+                ne prend tous les plis que l’on voit sur le visage. Il faut donc que ceux qui
+                représentent une passion d’amour, en soient en quelque sorte touchés, pendant qu’ils
+                la représentent. Et il ne faut pas s’imaginer que l’on puisse effacer de son esprit
+                cette impression qu’on y a excitée volontairement, et qu’elle ne laisse pas en nous
+                une grande disposition à cette même passion que l’on a bien voulu ressentir. Ainsi
+                la Comédie par sa nature même est une école et un exercice de vice, puisque c’est un
+                art, où il faut nécessairement exciter en soi-même des passions vicieuses. Que si
+                l’on considère que toute la vie des Comédiens est occupée dans cet exercice, qu’ils
+                la passent toute entière à apprendre en particulier, ou à répéter entre eux, ou à
+                représenter devant des spectateurs l’image de quelque vice, qu’ils n’ont presque
+                autre chose dans l’esprit, que ces folies ; on verra facilement qu’il est impossible
+                d’allier ce métier avec la pureté de notre Religion : et ainsi il faut avouer que
+                c’est un métier profane, et indigne d’un Chrétien ; que ceux qui l’exercent, sont
+                obligés de le quitter, comme tous les Conciles le leur ordonnent, et par conséquent
+                qu’il n’est point permis aux autres de contribuer à les entretenir dans une
+                profession contraire au Christianisme, ni de l’autoriser par leur
+              présence. »</p></quote>
+
             <p>Et ce qui doit faire rougir les Chrétiens qui se déclarent pour la défense des
               Comédies ; les Païens mêmes ont reconnu que les Comédies ne peuvent être innocentes ni
               honnêtes : <quote>« La Comédie<seg type="exquote">, dit Cicéron<note place="margin"
@@ -16103,7 +15932,7 @@
                     l’Epître de la suite du Menteur.</note>,</seg> que les Auteurs de Comédie aient
                 trouvé le moyen de plaire, ils sont quittes envers leur art ; et s’ils pèchent, ce
                 n’est pas contre lui, c’est contre les bonnes mœurs.… Celui qui joint l’utile à
-                l’agréable, fait plus qu’il n’était obligé de faire...</quote></p>
+                l’agréable, fait plus qu’il n’était obligé de faire... »</quote></p>
             <p>
               <quote>« Aristote ne tient point du tout nécessaire la partie qui regarde les mœurs,
                 puisqu’il permet de la retrancher entièrement ; et demeure d’accord qu’on peut faire
@@ -16137,8 +15966,8 @@
           </div>
           <div>
             <head>Dissertation pag. 246. etc.</head>
-            <p>
-              <quote>« Et pour ne pas abandonner entièrement cette dernière pensée favorable à la
+
+            <quote><p>« Et pour ne pas abandonner entièrement cette dernière pensée favorable à la
                 représentation des Poèmes Dramatiques, je l’appuierai seulement du témoignage de
                 saint Thomas, qui par sa profession, par la sainteté de sa vie, et par l’excellence
                 de sa  doctrine, est tenu partout pour l’Ange de l’Ecole, et pour le plus célèbre de
@@ -16167,22 +15996,17 @@
                   justice en les payant du service qu’ils en reçoivent, si ce n’est qu’ils y
                   consument leur bien en des vaines profusions, ou qu’ils le donnent à des bouffons
                   qui ne s’emploient qu’à des divertissements illicites ; parce que c’est entretenir
-                  et favoriser leur péché.  »</quote></quote>
-            </p>
-            <p>
-              <quote>« Je veux bien qu’en cet endroit S. Thomas parle des Histrions au sens des
-                derniers siècles, et qu’il comprenne sous ce nom les Acteurs des Poèmes Dramatiques.
-                Car si l’on n’entendait par ce terme que les Mimes, et les Farceurs, son autorité
-                serait encore plus avantageuse aux autres, que l’on ne pourrait pas condamner contre
-                la résolution de ce grand Théologien, qui serait favorable à ceux-là même que les
-                Grecs méprisaient, que les Romains tenaient infâmes, et que jamais on ne leur doit
-                comparer.</quote>
-            </p>
-            <p>
-              <quote>« C’est par où je finis cette Dissertation ; car après l’autorité d’un
-                personnage si célèbre, je n’ai rien d’assez considérable pour donner quelque lumière
-                à sa doctrine, ni pour ajouter quelque ornement à mon discours. »</quote>
-            </p>
+                  et favoriser leur péché.  »</quote></p><p>Je veux bien qu’en cet endroit S. Thomas
+                parle des Histrions au sens des derniers siècles, et qu’il comprenne sous ce nom les
+                Acteurs des Poèmes Dramatiques. Car si l’on n’entendait par ce terme que les Mimes,
+                et les Farceurs, son autorité serait encore plus avantageuse aux autres, que l’on ne
+                pourrait pas condamner contre la résolution de ce grand Théologien, qui serait
+                favorable à ceux-là même que les Grecs méprisaient, que les Romains tenaient
+                infâmes, et que jamais on ne leur doit comparer.</p><p>C’est par où je finis cette
+                Dissertation ; car après l’autorité d’un personnage si célèbre, je n’ai rien d’assez
+                considérable pour donner quelque lumière à sa doctrine, ni pour ajouter quelque
+                ornement à mon discours. »</p></quote>
+
           </div>
           <div>
             <head>XII. Réfutation.</head>
@@ -16284,13 +16108,12 @@
                 abolir ce métier, ni obliger ceux qui l’exercent, à le quitter ; car il paraît au
                 contraire par l’exemple qu’allègue saint Thomas, qu’on doit obliger ceux qui
                 exercent ce métier, de le quitter afin qu’ils puissent obtenir leur salut. Voici cet
-                exemple tel qu’il est rapporté dans la vie des Pères.</p>
-              <p>
-                <pb n="363" xml:id="p363"/>
-                <quote>« Nous apprîmes <seg type="exquote">, dit Ruffin <note place="margin"
+                exemple tel qu’il est rapporté dans la vie des Pères.<pb n="363" xml:id="p363"/></p>
+
+
+              <quote><p>« Nous apprîmes <seg type="exquote">, dit Ruffin <note place="margin"
                       resp="author">
-                      <p>
-                        <quote>« De hoc (S. Paphnutio) fidelissima Patrum narratione comperimus,
+                      <quote><p>« De hoc (S. Paphnutio) fidelissima Patrum narratione comperimus,
                           quod cum fuisset vitæ Angelicæ, quodam tempore oraverit Deum, ut sibi
                           ostenderet, cui sanctorum similis haberetur. Assistens vero Angelus
                           respondit ei quod similis esset symphoniaco cuidam, qui in vico illo
@@ -16300,44 +16123,39 @@
                           operis gestum sit ei, omnesque actus ejus curiosius discutit. At ille
                           respondit quod res erat, se esse indignissimæ vitæ hominem peccatorem,
                           atque ante non multum temporis, ex latrone, ad illud quod nunc exercere
-                          videretur, fœdum artificium devolutum.</quote></p>
-                      <p>
-                        <quote>« Paphnutius eo magis instabat, requirens si quid ei forte, vel inter
-                          latrocinia pii operis fuisset admissum. Nihil, inquit, mihi conscius sum
-                          boni : hoc tamen scio, quod cum inter latrones essem, capta est aliquando
-                          a nobis Virgo Deo consacrata : cujus cum cæteri mei collegæ latrones
-                          cuperent eripere pudorem, objeci me in medium, et eripui de contaminatione
-                          latronum, et nocte deducens eam ad vicum, domui suæ restitui
-                          intactam.</quote>
-                      </p>
-                      <p>
-                        <quote>« Alio quoque tempore inveni mulierem honestæ formæ in eremo
-                          oberrantem. Hæc cum interrogaretur a me, cur aut quo modo in hæc loca
-                          advenisset ? Respondit : Nihil me interroges infelicissimam mulierem nec
-                          causas requiras ; sed si ancillam placet habere, abducito quo vis. Mihi
-                          enim infelici est maritus, qui debiti fiscalis gratiam sæpe suspensus, et
-                          flagellatus, ac pœnis omnibus cruciatus servatur in carcere, nec aliam ob
-                          causam producitur, nisi ut tormenta patiatur. Tres autem nobis filii
-                          fuerunt, qui jam pro ejusdem debiti necessitate detenti sunt. Ego quoque
-                          miserrima, quia ad similes pœnas inquiror, de loco ad locum fugitans,
-                          inedia, miseriaque confecta, per hæc nunc latitans oberro loca, triduum
-                          jam hoc sine cibo ducens. Ego ubi hæc audivi, miseratus adduxi eam ad
-                          speluncam, et reficiens animam, ejus fame collapsam, dedi etiam ei
-                          trecentos solidos, pro quibus se, ac maritum, et filios, non solum
-                          servituti, sed et suppliciis asserebat obnoxios. Et revocata ea ad
-                          civitatem, omnes ea data pecunia liberavit.</quote>
-                      </p>
-                      <p>   «<quote>Tunc Pater Paphnutius, ego, inquit, nihil tale feci ; tamen
-                          credo etiam ad te pervenisse, quod celebre Paphnutii nomen inter Monachos
-                          habeatur : fuit enim mihi non mediocris studii, ut vitam meam in ejusmodi
-                          excolorem disciplinis. Deus igitur de te mihi rivelavit, quia nihilo minus
-                          apud ipsum meriti habeas, quam ego. Quia ergo, frater, vides te non minimo
-                          loco haberi apud Deum, non negligas animam tuam. At ille statim fistulas,
-                          quas manu gerebat, abjiciens, secutus est eum ad eremum, et artem musicam,
-                          in spiritualem commutans vitæ, mentisque harmoniam, per integrum triennium
-                          arctissimæ se tradidit abstinentiæ, in psalmis et orationibus semetipsum
-                          diu noctuque exercens, atque iter celeste animi virtutibus agens, inter
-                          sanctorum Angelicos choros redditit spiritum. »</quote>
+                          videretur, fœdum artificium devolutum.</p><p>Paphnutius eo magis instabat,
+                          requirens si quid ei forte, vel inter latrocinia pii operis fuisset
+                          admissum. Nihil, inquit, mihi conscius sum boni : hoc tamen scio, quod cum
+                          inter latrones essem, capta est aliquando a nobis Virgo Deo consacrata :
+                          cujus cum cæteri mei collegæ latrones cuperent eripere pudorem, objeci me
+                          in medium, et eripui de contaminatione latronum, et nocte deducens eam ad
+                          vicum, domui suæ restitui intactam.</p><p>Alio quoque tempore inveni
+                          mulierem honestæ formæ in eremo oberrantem. Hæc cum interrogaretur a me,
+                          cur aut quo modo in hæc loca advenisset ? Respondit : Nihil me interroges
+                          infelicissimam mulierem nec causas requiras ; sed si ancillam placet
+                          habere, abducito quo vis. Mihi enim infelici est maritus, qui debiti
+                          fiscalis gratiam sæpe suspensus, et flagellatus, ac pœnis omnibus
+                          cruciatus servatur in carcere, nec aliam ob causam producitur, nisi ut
+                          tormenta patiatur. Tres autem nobis filii fuerunt, qui jam pro ejusdem
+                          debiti necessitate detenti sunt. Ego quoque miserrima, quia ad similes
+                          pœnas inquiror, de loco ad locum fugitans, inedia, miseriaque confecta,
+                          per hæc nunc latitans oberro loca, triduum jam hoc sine cibo ducens. Ego
+                          ubi hæc audivi, miseratus adduxi eam ad speluncam, et reficiens animam,
+                          ejus fame collapsam, dedi etiam ei trecentos solidos, pro quibus se, ac
+                          maritum, et filios, non solum servituti, sed et suppliciis asserebat
+                          obnoxios. Et revocata ea ad civitatem, omnes ea data pecunia
+                          liberavit.</p><p>Tunc Pater Paphnutius, ego, inquit, nihil tale feci ;
+                          tamen credo etiam ad te pervenisse, quod celebre Paphnutii nomen inter
+                          Monachos habeatur : fuit enim mihi non mediocris studii, ut vitam meam in
+                          ejusmodi excolorem disciplinis. Deus igitur de te mihi rivelavit, quia
+                          nihilo minus apud ipsum meriti habeas, quam ego. Quia ergo, frater, vides
+                          te non minimo loco haberi apud Deum, non negligas animam tuam. At ille
+                          statim fistulas, quas manu gerebat, abjiciens, secutus est eum ad eremum,
+                          et artem musicam, in spiritualem commutans vitæ, mentisque harmoniam, per
+                          integrum triennium arctissimæ se tradidit abstinentiæ, in psalmis et
+                          orationibus semetipsum diu noctuque exercens, atque iter celeste animi
+                          virtutibus agens, inter sanctorum Angelicos choros redditit
+                          spiritum. »</p></quote><p>
                         <hi rend="i">De vitis Patrum</hi> l. 2. Aut. Ruff. de S. Paphnutio. </p>
                     </note>,</seg> par le rapport très fidèle que ces bons Pères nous en firent, que
                   le saint homme Paphnuce, qui menait sur la terre une vie toute angélique, ayant un
@@ -16349,53 +16167,48 @@
                   l’interrogea très particulièrement de toutes ses actions : à quoi il lui répondit,
                   selon la vérité, qu’il était un grand pécheur, qu’il avait fait une vie infâme, et
                   que de voleur qu’il était auparavant, il était passé dans le métier honteux qu’il
-                  lui voyait exercer alors.</quote>
-              </p>
-              <p>
-                <quote>« Plus il lui parlait de la sorte, et plus Paphnuce le pressait de lui dire,
-                  si au milieu de ses voleries, il n’avait point fait par hasard quelque bonne
-                  œuvre. Je ne le crois pas, lui répondit-il ; et tout ce dont je me souviens est,
-                  qu’étant avec d’autres voleurs nous prîmes un jour une Vierge consacrée à Dieu,
-                  laquelle mes compagnons voulant violer, je m’y opposai, et l’arrachai d’entre
-                  leurs mains, et l’ayant conduite de nuit dans le bourg d’où elle était, je la
-                  ramenai en sa maison aussi chaste qu’elle en était sortie.</quote>
-              </p>
-              <p>
-                <quote>« Une autre fois je rencontrai une belle femme errante dans le désert ; et
-                  lui ayant demandé le sujet qui l’y avait ainsi amenée ; elle me répondit :
-                    <quote>« Ne vous informez point des malheurs d’une pauvre misérable, et n’ayez
-                    point de curiosité d’en savoir la cause ; mais si vous me voulez prendre pour
-                    servante, menez-moi où vous voudrez. Car la fortune m’a réduite en tel état, que
-                    mon mari après avoir enduré mille tourments pour s’être trouvé redevable des
-                    deniers publics, est toujours retenu en prison, d’où on ne le tire que pour lui
-                    faire souffrir de nouvelles peines. Nous avons trois fils qui ont aussi été
-                    arrêtés pour cette dette et d’autant que l’on me cherche, afin de me traiter de
-                    la même sorte, je fuis d’un lieu en un autre, et j’erre pour me cacher dans les
-                    endroits les plus écartés de ce désert, où je me trouve <pb n="364"
-                      xml:id="p364"/> accablée de nécessité, et de misère, y ayant déjà trois jours
-                    que je n’ai mangé. »</quote> Je fus si touché de compassion de ces paroles, que
-                  je la menai dans ma caverne, où après qu’elle fut revenue de cette extrême
-                  faiblesse où elle était réduite faute de manger, je lui donnai trois cents pièces
-                  d’argent, pour lesquelles elle disait que son mari, ses enfants, et elle, non
-                  seulement avaient perdu la liberté, mais se trouvaient engagés dans les tourments.
-                  Et ainsi s’en étant retournée dans la ville, et ayant payé cette somme, ils furent
-                  tous délivrés d’une si extrême misère. Alors Paphnuce lui dit : <quote>« En vérité
-                    je n’ai rien fait de semblable ; et j’estime toutefois que vous n’ignorez pas
-                    que le nom de Paphnuce est assez connu parmi les Solitaires, à cause du grand
-                    désir que j’ai eu de m’instruire, et de m’exercer en leur sainte manière de
-                    vivre : et Dieu m’a relevé sur votre sujet, qu’il ne vous considère pas moins
-                    que moi. C’est pourquoi, mon frère, puisque vous voyez que vous ne tenez pas
-                    l’une des moindres places auprès de sa divine Majesté, ne négligez point de
-                    prendre soin de votre âme. »</quote> Cet homme n’eut pas plutôt entendu ces
-                  paroles, qu’il jeta les flûtes qu’il avait entre les mains, et le suivit dans le
-                  désert où il changea l’art de la Musique dont il faisait profession, en une
-                  harmonie spirituelle, par laquelle il régla de telle sorte tous les mouvements de
-                  son âme, et toutes les actions de sa vie, qu’après avoir durant trois années
-                  entières vécu dans une très étroite abstinence, passant les jours, et les nuits à
-                  chanter des Psaumes, et à prier, et marchant dans le chemin du Paradis par ses
-                  vertus, et par ses mérites, il rendit l’esprit au milieu des bienheureux Chœurs
-                  des Anges. »</quote>
-              </p>
+                  lui voyait exercer alors.</p><p>Plus il lui parlait de la sorte, et plus Paphnuce
+                  le pressait de lui dire, si au milieu de ses voleries, il n’avait point fait par
+                  hasard quelque bonne œuvre. Je ne le crois pas, lui répondit-il ; et tout ce dont
+                  je me souviens est, qu’étant avec d’autres voleurs nous prîmes un jour une Vierge
+                  consacrée à Dieu, laquelle mes compagnons voulant violer, je m’y opposai, et
+                  l’arrachai d’entre leurs mains, et l’ayant conduite de nuit dans le bourg d’où
+                  elle était, je la ramenai en sa maison aussi chaste qu’elle en
+                  était sortie.</p><p>Une autre fois je rencontrai une belle femme errante dans le
+                  désert ; et lui ayant demandé le sujet qui l’y avait ainsi amenée ; elle me
+                  répondit : <quote>« Ne vous informez point des malheurs d’une pauvre misérable, et
+                    n’ayez point de curiosité d’en savoir la cause ; mais si vous me voulez prendre
+                    pour servante, menez-moi où vous voudrez. Car la fortune m’a réduite en tel
+                    état, que mon mari après avoir enduré mille tourments pour s’être trouvé
+                    redevable des deniers publics, est toujours retenu en prison, d’où on ne le tire
+                    que pour lui faire souffrir de nouvelles peines. Nous avons trois fils qui ont
+                    aussi été arrêtés pour cette dette et d’autant que l’on me cherche, afin de me
+                    traiter de la même sorte, je fuis d’un lieu en un autre, et j’erre pour me
+                    cacher dans les endroits les plus écartés de ce désert, où je me trouve <pb
+                      n="364" xml:id="p364"/> accablée de nécessité, et de misère, y ayant déjà
+                    trois jours que je n’ai mangé. »</quote> Je fus si touché de compassion de ces
+                  paroles, que je la menai dans ma caverne, où après qu’elle fut revenue de cette
+                  extrême faiblesse où elle était réduite faute de manger, je lui donnai trois cents
+                  pièces d’argent, pour lesquelles elle disait que son mari, ses enfants, et elle,
+                  non seulement avaient perdu la liberté, mais se trouvaient engagés dans les
+                  tourments. Et ainsi s’en étant retournée dans la ville, et ayant payé cette somme,
+                  ils furent tous délivrés d’une si extrême misère. Alors Paphnuce lui dit :
+                    <quote>« En vérité je n’ai rien fait de semblable ; et j’estime toutefois que
+                    vous n’ignorez pas que le nom de Paphnuce est assez connu parmi les Solitaires,
+                    à cause du grand désir que j’ai eu de m’instruire, et de m’exercer en leur
+                    sainte manière de vivre : et Dieu m’a relevé sur votre sujet, qu’il ne vous
+                    considère pas moins que moi. C’est pourquoi, mon frère, puisque vous voyez que
+                    vous ne tenez pas l’une des moindres places auprès de sa divine Majesté, ne
+                    négligez point de prendre soin de votre âme. »</quote> Cet homme n’eut pas
+                  plutôt entendu ces paroles, qu’il jeta les flûtes qu’il avait entre les mains, et
+                  le suivit dans le désert où il changea l’art de la Musique dont il
+                  faisait profession, en une harmonie spirituelle, par laquelle il régla de telle
+                  sorte tous les mouvements de son âme, et toutes les actions de sa vie, qu’après
+                  avoir durant trois années entières vécu dans une très étroite abstinence, passant
+                  les jours, et les nuits à chanter des Psaumes, et à prier, et marchant dans le
+                  chemin du Paradis par ses vertus, et par ses mérites, il rendit l’esprit au milieu
+                  des bienheureux Chœurs des Anges. »</p></quote>
+
             </div>
             <div>
               <head>II. EXPLICATION DU PASSAGE de S. Thomas allégué ci-dessus.</head>
@@ -16443,11 +16256,10 @@
                 était impossible de réformer tellement le métier des Comédiens, et des Histrions,
                 qu’il pût répondre à cette idée métaphysique, il bannit de son Royaume toutes ces
                 sortes de gens.</p>
-              <p>
-                <quote>« Je dis <seg type="exquote">, dit le P. Guzman Jésuite <note place="margin"
+
+              <quote><p>« Je dis <seg type="exquote">, dit le P. Guzman Jésuite <note place="margin"
                       resp="author">
-                      <p>
-                        <quote>« Yo digo que aunque hablando en rigor escholastico, y con el que
+                      <quote><p>« Yo digo que aunque hablando en rigor escholastico, y con el que
                           habla S. Thomas, el officio de representar Comœdias, quanto es de sujo, no
                           sea malo, si no es que las circunstancias, que andan como anexas, y
                           vinculadas à el, le vicien, y estraguen, es tan difficultoso el desnudar
@@ -16501,53 +16313,48 @@
                           escrito. Acabemos con lo que santo Tomas dize : <quote>« Y los tales
                             representantes aunque solo se occupan en dar plazer à los hombres ; pero
                             en orden à Dios pueden, y suelen hazer otras obras buenas, orar, dar
-                            limosna, et c. »</quote></quote></p>
-                      <p>
-                        <quote>« El mismo santo en los Commentarios que hizo sobre el Maestro de las
-                          sentantias, <quote>« Ay<seg type="exquote">, dize,</seg> tre maneras de
-                            juegos, y entrentenimientos unos que de suyo son torpes, y estos todos
-                            los deven huyr, quales eran las representationes que se hazian en los
-                            Theatros, que provocavan à luxuria »</quote> : de vede aludir à las
-                          fiestas de Flora. En las otras dos maneras de Juegos puede aver falta, y
-                          escesso, por las circonstancias de tiempo, lugar, y personnas, que se
-                          apuntaron arriba. </quote>
-                      </p>
-                      <p>
-                        <quote>« Esta es la doctrina de santo Tomas, explicada con la mayor claridad
-                          que la hesabido, y podido explicar. Bolvamos à aquella conditional, à
-                          aquel conque, que el santo añade.Que como en sententia dada en favor de un
-                          mayorasgo, Conque pagne, tanta candidad, que algunas vezes suele ser tan
-                          grande, que apela de la sentencia aun el mismo, en cuyo favor se dio,
-                          diziendo, que es mas lo que le mandan dar, que lo que le queda, y que es
-                          intolerable carga aquella, al fin que son mas los reditos, que el
-                          principal : Manda el santo en su sentencia à esta gente, que exerciten en
-                          hora buena, su officio, conque ny en obras ny en palabras menos decentes,
-                          excedan un punto de la razon. Pienso, que si bien no apelan desta
-                          sentencia, lo ordinario haze contra ella. Sino, digan me como cumplen con
-                          este conque, en una Comedia de Medusa, ò de Medea, de Perseo, de Theseo,
-                          de Marte, ò de Venus ò en la Comedia de los donayres del otro, o de los
-                          zelos del otro, o de la travesura de l’otro, ò de la Boda entre los otros
-                          dos maridos, al fin en un en redo de amor, tinto todo en color de sangre,
-                          y carne, lleno desde laloa, hasta el valete, et plaudite, de dichos, y
-                          hechos poco honnestos, poco graves, de razones, y agudezas, ò
-                          descubrietamente inhonnestas, ò (como dizen) tan coloradas, que pueden
-                          sacar al rostro el color de la verguença ? no hablo de los appendizes de
-                          las Comedias, de los entremeses, bayles, letras, sones, cantares, donayres
-                          sobie-salientes, y añididos, que son como adherentes, y salsas, que
-                          mientras dan mas gusto, estragan las costumbres mas ; que estas cosas no
-                          quieren entren en cuenta de Comedia ; y assi aun en las mas santas se
-                          suelen añadir. Visto pues todo lo dicho, y que con la experiencia de tan
-                          largo tiempo no es possible poner medio, ò remedio en esto, ni
-                          circunstancionar estas Comedias con las reglas de la razon, excluyendo
-                          dellas toda cosa torpe e inhonesta, y que como a hora lo ordinario se
-                          uzan, y se usaran ya siempre, son como la Hydra Lernea que cortada una
-                          cabeça, nace otra, ò como un braço tan encancerado, que es mas facil, y
-                          mas saludable, cortar le todo, que entresacar la parte podrida, que es la
-                          mayor, jusgo convenir mas desterrar de le Republica Christiana estas
-                          Comœdias, que reformar las, y permittir las ; como el Catholico Rey don
-                          Phelipe segundo de gloriosa memoria lo hizo al cabo de su dichosa vida.
-                           »</quote> El P. Pedro de Guzman <hi rend="i"> de los bienes del honesto
-                          trabajo</hi>, discurso 6. §. 8. </p>
+                            limosna, et c. »</quote></p><p>El mismo santo en los Commentarios que
+                          hizo sobre el Maestro de las sentantias, <quote>« Ay<seg type="exquote">,
+                              dize,</seg> tre maneras de juegos, y entrentenimientos unos que de
+                            suyo son torpes, y estos todos los deven huyr, quales eran las
+                            representationes que se hazian en los Theatros, que provocavan à
+                            luxuria »</quote> : de vede aludir à las fiestas de Flora. En las otras
+                          dos maneras de Juegos puede aver falta, y escesso, por las circonstancias
+                          de tiempo, lugar, y personnas, que se apuntaron arriba.</p><p>Esta es la
+                          doctrina de santo Tomas, explicada con la mayor claridad que la hesabido,
+                          y podido explicar. Bolvamos à aquella conditional, à aquel conque, que el
+                          santo añade.Que como en sententia dada en favor de un mayorasgo, Conque
+                          pagne, tanta candidad, que algunas vezes suele ser tan grande, que apela
+                          de la sentencia aun el mismo, en cuyo favor se dio, diziendo, que es mas
+                          lo que le mandan dar, que lo que le queda, y que es intolerable carga
+                          aquella, al fin que son mas los reditos, que el principal : Manda el santo
+                          en su sentencia à esta gente, que exerciten en hora buena, su officio,
+                          conque ny en obras ny en palabras menos decentes, excedan un punto de la
+                          razon. Pienso, que si bien no apelan desta sentencia, lo ordinario haze
+                          contra ella. Sino, digan me como cumplen con este conque, en una Comedia
+                          de Medusa, ò de Medea, de Perseo, de Theseo, de Marte, ò de Venus ò en la
+                          Comedia de los donayres del otro, o de los zelos del otro, o de la
+                          travesura de l’otro, ò de la Boda entre los otros dos maridos, al fin en
+                          un en redo de amor, tinto todo en color de sangre, y carne, lleno desde
+                          laloa, hasta el valete, et plaudite, de dichos, y hechos poco honnestos,
+                          poco graves, de razones, y agudezas, ò descubrietamente inhonnestas, ò
+                          (como dizen) tan coloradas, que pueden sacar al rostro el color de la
+                          verguença ? no hablo de los appendizes de las Comedias, de los entremeses,
+                          bayles, letras, sones, cantares, donayres sobie-salientes, y añididos, que
+                          son como adherentes, y salsas, que mientras dan mas gusto, estragan las
+                          costumbres mas ; que estas cosas no quieren entren en cuenta de Comedia ;
+                          y assi aun en las mas santas se suelen añadir. Visto pues todo lo dicho, y
+                          que con la experiencia de tan largo tiempo no es possible poner medio, ò
+                          remedio en esto, ni circunstancionar estas Comedias con las reglas de la
+                          razon, excluyendo dellas toda cosa torpe e inhonesta, y que como a hora lo
+                          ordinario se uzan, y se usaran ya siempre, son como la Hydra Lernea que
+                          cortada una cabeça, nace otra, ò como un braço tan encancerado, que es mas
+                          facil, y mas saludable, cortar le todo, que entresacar la parte podrida,
+                          que es la mayor, jusgo convenir mas desterrar de le Republica Christiana
+                          estas Comœdias, que reformar las, y permittir las ; como el Catholico Rey
+                          don Phelipe segundo de gloriosa memoria lo hizo al cabo de su dichosa
+                          vida.  »</p></quote><p> El P. Pedro de Guzman <hi rend="i"> de los bienes
+                          del honesto trabajo</hi>, discurso 6. §. 8. </p>
                     </note>,</seg> qu’encore qu’en parlant dans la rigueur de l’Ecole, et selon
                   l’expression même de saint Thomas, le métier de représenter des Comédies, ne soit
                   pas de lui-même mauvais, et qu’il n’y ait que les circonstances qui
@@ -16612,59 +16419,51 @@
                   Thomas ; Et quoique les Comédiens n’aient point d’autre occupation que de divertir
                   les hommes ; toutefois à l’égard de Dieu, ils peuvent faire d’autres bonnes
                   œuvres, et ils en font même souvent : ils prient Dieu, ils donnent l’aumône,
-                  etc.</quote>
-              </p>
-              <p>
-                <quote>« Le même Saint dans ses Commentaires sur le Maître des Sentences, In 4.
+                  etc.</p><p>Le même Saint dans ses Commentaires sur le Maître des Sentences, In 4.
                   dist. 16. q. 4. art. 2. <quote>« Il y a <seg type="exquote">, dit-il,</seg> trois
                     sortes de jeux et de divertissement : les uns sont déshonnêtes d’eux-mêmes ; et
                     tout le monde les doit fuir : telles étaient les représentations de Théâtre, qui
                     portaient à l’impureté. »</quote> Il fait allusion aux jeux de Flore. Quant aux
                   autres jeux il y peut avoir du dérèglement, soit à l’égard des circonstances du
                   temps et du lieu ; soit à l’égard des personnes, comme nous l’avons marqué
-                  ci-dessus.</quote>
-              </p>
-              <p>
-                <quote>« C’est la doctrine de S. Thomas que j’ai expliquée le plus <pb n="369"
-                    xml:id="p369"/> clairement qu’il m’a été possible. Revenons à cette condition
-                  qu’ajoute ce S. Docteur : «  <hi rend="i">Pourvu</hi>  ; Comme dans une sentence
-                  donnée en faveur d’un ainé, <hi rend="i">à condition</hi> qu’il paie une certaine
-                  somme, il arrive quelquefois que cette somme qu’on l’oblige de donner, est si
-                  grande, qu’il se rend appelant de cette sentence qui a été donnée en sa faveur,
-                  disant que ce qu’on l’oblige de donner surpasse ce qui lui reste ; ce qui lui est
-                  une charge insupportable : qu’enfin ce qu’on lui ordonne de payer, monte plus que
-                  le principal. De même S. Thomas permet aux Comédiens d’exercer leur métier à la
-                  bonne heure, <hi rend="i">pourvu</hi> , qu’ils ne s’écartent pas d’un seul point
-                  de la raison, soit dans les actions ; soit dans les paroles indécentes. Je crois
-                  que s’ils ne se rendent pas appelants de cette sentence, ils y contreviennent
-                  d’ordinaire. Car je les prie de me dire comment ils accomplissent cette condition,
-                  Pourvu etc. : dans la Comédie de Méduse, de Médée, de Persée, de Thésée, de Mars,
-                  et de Vénus ? ou lorsqu’ils représentent des galanteries, des amours, des
-                  jalousies, des folies de jeunesse, la noce de deux maris ? Enfin dans les Comédies
-                  qui n’ont que des intrigues d’amour, tout de sang, et de chair, et qui depuis le
-                  commencement jusqu’à la fin sont pleines de paroles, et d’actions peu honnêtes, et
-                  peu modestes, de raisonnement, et d’adresses, ou ouvertement impudiques, ou, comme
-                  on dit, tellement colorés qu’ils peuvent faire changer de couleur et faire rougir
-                  de honte ? Je ne parle point des autres choses qui accompagnent les Comédies, des
-                  Entractes, des Ballets, et de leurs vers, des airs, et des chansons, et des
-                  bouffonneries extravagantes qu’on y ajoute, comme des ragoûts, et des
-                  assaisonnements, qui corrompent d’autant plus les bonnes mœurs, que plus ils sont
-                  agréables. Et quoique ces choses ne soient pas du corps des Comédies, on ne laisse
-                  pas de les y joindre, même à celles dont les sujets sont les plus saints.</quote>
-              </p>
-              <p>
-                <quote>« Après avoir considéré tout ce que je viens de dire ; et l’expérience de
-                  tant de siècles nous ayant fait connaître, qu’il est impossible de modérer, de
-                  réformer, et d’ajuster les Comédies avec les règles de la raison, en ôtant tout ce
-                  qu’il y a de sale, et de déshonnête, et qu’en l’état où elles sont <pb n="370"
-                    xml:id="p370"/> maintenant pour l’ordinaire, et où elles ont toujours été. Elles
-                  sont comme l’Hydre de Lerne, à qui lorsqu’on coupait une tête, il en renaissait
-                  une autre. Ou comme un bras si gâté de gangrène, qu’il est plus facile, et plus
-                  salutaire de le couper tout à fait, que d’en retrancher ce qui en est la plus
-                  grande partie. J’estime qu’il vaut mieux bannir les Comédiens de la république
-                  chrétienne, que de les réformer, et de les tolérer. C’est ce que fit le Roi
-                  Catholique Philippe II de glorieuse mémoire à la fin de sa vie. »</quote>
-              </p>
+                  ci-dessus.</p><p>C’est la doctrine de S. Thomas que j’ai expliquée le plus <pb
+                    n="369" xml:id="p369"/> clairement qu’il m’a été possible. Revenons à cette
+                  condition qu’ajoute ce S. Docteur : «  <hi rend="i">Pourvu</hi>  ; Comme dans une
+                  sentence donnée en faveur d’un ainé, <hi rend="i">à condition</hi> qu’il paie une
+                  certaine somme, il arrive quelquefois que cette somme qu’on l’oblige de donner,
+                  est si grande, qu’il se rend appelant de cette sentence qui a été donnée en sa
+                  faveur, disant que ce qu’on l’oblige de donner surpasse ce qui lui reste ; ce qui
+                  lui est une charge insupportable : qu’enfin ce qu’on lui ordonne de payer, monte
+                  plus que le principal. De même S. Thomas permet aux Comédiens d’exercer leur
+                  métier à la bonne heure, <hi rend="i">pourvu</hi> , qu’ils ne s’écartent pas d’un
+                  seul point de la raison, soit dans les actions ; soit dans les paroles indécentes.
+                  Je crois que s’ils ne se rendent pas appelants de cette sentence, ils y
+                  contreviennent d’ordinaire. Car je les prie de me dire comment ils accomplissent
+                  cette condition, Pourvu etc. : dans la Comédie de Méduse, de Médée, de Persée, de
+                  Thésée, de Mars, et de Vénus ? ou lorsqu’ils représentent des galanteries, des
+                  amours, des jalousies, des folies de jeunesse, la noce de deux maris ? Enfin dans
+                  les Comédies qui n’ont que des intrigues d’amour, tout de sang, et de chair, et
+                  qui depuis le commencement jusqu’à la fin sont pleines de paroles, et d’actions
+                  peu honnêtes, et peu modestes, de raisonnement, et d’adresses, ou ouvertement
+                  impudiques, ou, comme on dit, tellement colorés qu’ils peuvent faire changer de
+                  couleur et faire rougir de honte ? Je ne parle point des autres choses qui
+                  accompagnent les Comédies, des Entractes, des Ballets, et de leurs vers, des airs,
+                  et des chansons, et des bouffonneries extravagantes qu’on y ajoute, comme des
+                  ragoûts, et des assaisonnements, qui corrompent d’autant plus les bonnes mœurs,
+                  que plus ils sont agréables. Et quoique ces choses ne soient pas du corps des
+                  Comédies, on ne laisse pas de les y joindre, même à celles dont les sujets sont
+                  les plus saints.</p><p>Après avoir considéré tout ce que je viens de dire ; et
+                  l’expérience de tant de siècles nous ayant fait connaître, qu’il est impossible de
+                  modérer, de réformer, et d’ajuster les Comédies avec les règles de la raison, en
+                  ôtant tout ce qu’il y a de sale, et de déshonnête, et qu’en l’état où elles sont
+                    <pb n="370" xml:id="p370"/> maintenant pour l’ordinaire, et où elles ont
+                  toujours été. Elles sont comme l’Hydre de Lerne, à qui lorsqu’on coupait une tête,
+                  il en renaissait une autre. Ou comme un bras si gâté de gangrène, qu’il est plus
+                  facile, et plus salutaire de le couper tout à fait, que d’en retrancher ce qui en
+                  est la plus grande partie. J’estime qu’il vaut mieux bannir les Comédiens de la
+                  république chrétienne, que de les réformer, et de les tolérer. C’est ce que fit le
+                  Roi Catholique Philippe II de glorieuse mémoire à la fin de sa vie. »</p></quote>
+
               <p>Je pouvais finir ici mes Réfutations, puisque c’est ici la fin de la <hi rend="i"
                   >Dissertation sur la condamnation des Théâtres</hi>. Mais j’ai cru ne devoir pas
                 m’arrêter au treizième siècle qui est le siècle de de S. Thomas : Jugeant qu’il
@@ -16729,7 +16528,7 @@
                         facies abjectarum feminarum illarum defixos habent oculos, qua fronte
                         poterunt dicere, quod eas non viderint ad concupiscendum, ubi verba quoque
                         accedunt fracta, lascivaque, ubi cantiones meretriciæ, ubi voces vehementer
-                        ad voluptatem incitant ?...</quote></p>
+                        ad voluptatem incitant ?... »</quote></p>
                     <p>
                       <quote>« Etenim si hic ubi Psalmi, ubi divinorum eloquiorum enarratio, ubi Dei
                         metus, multaque reverentia, fræquenter, ceu latro quispiam versetur, clam
@@ -16739,7 +16538,7 @@
                         illam superare concupiscentiam ? Rursum si non possunt, quomodo poterunt
                         unquam, ab adulterii crimine absolvi ? Tunc qui non liberi sunt ab adulterii
                         crimine, quomodo potentur absque penitentia ad hæc sacra vestibula accedere,
-                        hujusque præclari conventus esse participes ?</quote>
+                        hujusque præclari conventus esse participes ? »</quote>
                     </p>
                     <p>
                       <quote>« Quapropter equidem hortor, rogoque ut prius confessione, ac
@@ -16762,7 +16561,7 @@
                 insupportable pour y aller ; et y passent tout le jour à regarder ces femmes
                 infâmes ; auront-ils l’impudence de dire, qu’ils ne les voient pas pour les désirer,
                 lorsque leurs paroles dissolues, et lascives, les voix et les chants impudiques les
-                portent à la volupté ?....</quote>
+                portent à la volupté ?.... »</quote>
             </p>
             <p>
               <quote>« Car si en ce lieu où l’on chante les Psaumes, où l’on explique la parole de
@@ -16773,7 +16572,8 @@
                 de toutes parts, comment pourront-ils surmonter la concupiscence : Et s’ils ne la
                 peuvent pas surmonter, comment pourront-ils être exempts du crime d’adultère. Et
                 étant souillés de ce crime, comment pourront-ils entrer dans l’Eglise, et être reçus
-                dans la communion de cette Sainte Assemblée ; sans en avoir fait pénitence ?</quote>
+                dans la communion de cette Sainte Assemblée ; sans en avoir fait
+                pénitence ? »</quote>
             </p>
             <p>
               <quote>« C’est pourquoi je conjure et je prie ces personnes de se purifier par
@@ -16865,77 +16665,75 @@
                 Farceurs. »</quote> Voyez la 11. Réfutation du chapitre 10.</p>
             <p>François Patrice de Sienne, Evêque de Gaïète représente au Pape Sixte quatrième,
               combien les Tragédies et les Comédies sont opposées à la pureté des mœurs, et à la
-              sainteté de notre Religion, de sorte qu’elles doivent être bannies de la Chrétienté.
-                <quote>« Il n’y a presque point de Tragédie, <seg type="exquote">dit-il<note
-                    place="margin" resp="author"><p>
-                      <quote>« Tragœdia pene omnis extrudenda est ab optima civitate : quam quidem
+              sainteté de notre Religion, de sorte qu’elles doivent être bannies de la
+              Chrétienté.</p>
+            <quote><p>« Il n’y a presque point de Tragédie, <seg type="exquote">dit-il<note
+                    place="margin" resp="author">
+                    <quote><p>« Tragœdia pene omnis extrudenda est ab optima civitate : quam quidem
                         Solon Thespin docere prohibuit, ut inutilem, et eam falsiloquentiam
                         appellavit : Lacedemonii quoque libros Æschili Poëtæ Sparta urbe asportari
                         jusserunt, tanquam inutiles, et editos potius ad hominum mores corrumpendos,
                         quam ad aliquam bonarum artium disciplinam. Nec immerito explodenda est ex
                         omni civili spectaculo Tragœdia. Habet enim in se violentiam quamdam nimiam
                         mixtam desperationi, quæfacile ex stultis insanos reddat, et leves in
-                        furorem compellat…</quote></p><p><quote>« Comœdiam quam in Sicilia primum
-                        adinventam dicunt, in spectaculis etiam recitari non placet : corrompit
-                        namque hominum mores, eosque effœminatos reddit, et ad libidinem,
-                        luxuriamque, compellit. Atque illi Massilienses quondam severitatis
-                        custodes, nullum aditum in urbem permiserunt. Comœdiarum namque argumenta,
-                        et stupra continent ; quocirca spectandi consuetudo, imitandi etiam
-                        licentiam facit. Nam ut apud Ciceronem in libris de Republica dicit Scipio.
-                        Numquam Comœdiæ, nisi consuetudo vitæ pateretur, probare sua in Theatris
-                        flagitia potuissent…Earum fabularum actores, et omnes qui ludicram artem
-                        exercebant, hoc est Histrionicam et Scenicam Romani veteres odio habuerunt ;
-                        unde lege cavebatur, ut qui ludicram exercet, in primis quatuordecim
-                        ordinibus ne sederet. Et apud Ciceronem idem Scipio idem testatur his
-                        verbis. Cum artem ludicram, scenicamque totam probro ducerent, genus id
-                        hominum non modo honore civium reliquorum carere, sed etiam tribu moveri,
-                        notatione censoria voluerunt. Exigatur igitur a Theatris Comœdia. »</quote>
-                      Franciscus Patricius Senensis Pont. Caiet. lib. 2. <hi rend="i">de Instit.
-                        Reip</hi>. tit. 6.</p></note></seg>, qui ne doive être bannie d’une ville
-                bien réglée. Solon défendit à Thespis l’exercice de cet art, comme étant inutile, et
-                ne servant qu’à apprendre à mentir. Et les Lacédémoniens ne purent souffrir dans
-                leur ville les livres du Poète Eschyle, les jugeant impertinents, et capables plutôt
-                de corrompre les mœurs, que de porter les hommes à quelque honnête exercice. Ce
-                n’est pas sans raison qu’on doit bannir entièrement des villes les spectacles des
-                Tragédies ; car elles ont des excès de transports si violents, et si pleins de
-                désespoir, qu’elles peuvent aisément rendre des fous, insensés, et jeter dans la
-                fureur des esprits faibles, et légers...</quote></p>
-            <p>
-              <quote>« Je n’approuve point aussi qu’on récite sur les Théâtres des Comédies, qu’on
-                dit avoir été inventées dans la Sicile : car elles corrompent les mœurs, et rendent
-                les hommes efféminés, les portant à l’oisiveté, et à l’impureté ; c’est pourquoi les
-                anciens Citoyens de Marseille gardaient si exactement la sévérité de leur
-                discipline, qu’ils ne recevaient point dans leur ville de Comédies dont la plupart
-                ne représentent que des adultères, et des amours impudiques ; de sorte qu’en
-                s’accoutumant à voir les représentations de ces crimes, on prend aussi la liberté de
-                les imiter. Et comme dit Scipion dans les livres que Cicéron a écrits de la
-                République, <quote>« on n’eût jamais approuvé les Comédies, et les crimes qu’elles
-                  exposaient sur le Théâtre, si les mœurs des hommes, qui étaient souillés des mêmes
-                  vices, ne l’eussent souffert »</quote>.… les Acteurs de ces fables, et tous ceux
-                qui exerçaient l’art de divertissement, c’est-à-dire l’art des Histrions, et des
-                Acteurs de la Scène, étaient si odieux aux anciens Romains, qu’il y avait une loi
-                parmi eux, qui défendait à ces sortes de gens de s’asseoir dans les sièges des <pb
-                  n="376" xml:id="p376"/> quatorze premiers rangs. C’est ce que témoigne Scipion
-                dans ces livres que Cicéron a écrits de la République en ces termes : <quote>« Les
-                  Romains estimant que l’art de divertissement, et tous les jeux de la Scène,
-                  étaient des choses honteuses, et infâmes, non seulement ils ont privé ces sortes
-                  de gens qui en sont les Acteurs, des honneurs, et des dignités dont la porte était
-                  ouverte aux autres Citoyens ; mais ils les ont même jugés dignes d’être notés par
-                  les Censeurs, pour être exclus de leurs tribus. Il faut donc bannir les Comédies
-                  des Théâtres. »</quote>. »</quote>
-            </p>
-            <p> Et dans le Livre 8. titre 14. <quote>«  <quote>« Il n’est point <seg type="exquote"
-                    >, dit-il,</seg>
-                  <note place="margin" resp="author"><quote>« Theatrorum ratio temporibus nostris
-                      minus necesaria est. Fabulæ enim omnes rejectæ, explosæque sunt, et severitate
-                      moris, religionisque sanctitate urbibus ejectæ ; quocirca supervacuum omnino
-                      esset, de statuendis Theatris plura dicere, cum vetera spectacula diruantur,
-                      et nova neutiquam ædificentur. »</quote> Idem lib. 8. tit. 14.</note>
-                  nécessaire de parler des Théâtres dans le temps où nous sommes ; car la sévérité
-                  de nos mœurs ; et la sainteté de notre Religion ont rejeté, et banni des villes
-                  toutes ces fables de l’antiquité ; et il serait inutile de traiter plus au long de
-                  la structure des Théâtres, puisqu’on les a démolis, et qu’on n’en bâtit point de
-                  nouveaux. »  »</quote></quote>
+                        furorem compellat…</p><p>Comœdiam quam in Sicilia primum adinventam dicunt,
+                        in spectaculis etiam recitari non placet : corrompit namque hominum mores,
+                        eosque effœminatos reddit, et ad libidinem, luxuriamque, compellit. Atque
+                        illi Massilienses quondam severitatis custodes, nullum aditum in urbem
+                        permiserunt. Comœdiarum namque argumenta, et stupra continent ; quocirca
+                        spectandi consuetudo, imitandi etiam licentiam facit. Nam ut apud Ciceronem
+                        in libris de Republica dicit Scipio. Numquam Comœdiæ, nisi consuetudo vitæ
+                        pateretur, probare sua in Theatris flagitia potuissent…Earum fabularum
+                        actores, et omnes qui ludicram artem exercebant, hoc est Histrionicam et
+                        Scenicam Romani veteres odio habuerunt ; unde lege cavebatur, ut qui
+                        ludicram exercet, in primis quatuordecim ordinibus ne sederet. Et apud
+                        Ciceronem idem Scipio idem testatur his verbis. Cum artem ludicram,
+                        scenicamque totam probro ducerent, genus id hominum non modo honore civium
+                        reliquorum carere, sed etiam tribu moveri, notatione censoria voluerunt.
+                        Exigatur igitur a Theatris Comœdia. »</p></quote><p> Franciscus Patricius
+                      Senensis Pont. Caiet. lib. 2. <hi rend="i">de Instit. Reip</hi>. tit.
+                    6.</p></note></seg>, qui ne doive être bannie d’une ville bien réglée. Solon
+                défendit à Thespis l’exercice de cet art, comme étant inutile, et ne servant qu’à
+                apprendre à mentir. Et les Lacédémoniens ne purent souffrir dans leur ville les
+                livres du Poète Eschyle, les jugeant impertinents, et capables plutôt de corrompre
+                les mœurs, que de porter les hommes à quelque honnête exercice. Ce n’est pas sans
+                raison qu’on doit bannir entièrement des villes les spectacles des Tragédies ; car
+                elles ont des excès de transports si violents, et si pleins de désespoir, qu’elles
+                peuvent aisément rendre des fous, insensés, et jeter dans la fureur des esprits
+                faibles, et légers... </p><p>Je n’approuve point aussi qu’on récite sur les Théâtres
+                des Comédies, qu’on dit avoir été inventées dans la Sicile : car elles corrompent
+                les mœurs, et rendent les hommes efféminés, les portant à l’oisiveté, et à
+                l’impureté ; c’est pourquoi les anciens Citoyens de Marseille gardaient si
+                exactement la sévérité de leur discipline, qu’ils ne recevaient point dans leur
+                ville de Comédies dont la plupart ne représentent que des adultères, et des amours
+                impudiques ; de sorte qu’en s’accoutumant à voir les représentations de ces crimes,
+                on prend aussi la liberté de les imiter. Et comme dit Scipion dans les livres que
+                Cicéron a écrits de la République, <quote>« on n’eût jamais approuvé les Comédies,
+                  et les crimes qu’elles exposaient sur le Théâtre, si les mœurs des hommes, qui
+                  étaient souillés des mêmes vices, ne l’eussent souffert »</quote>.… les Acteurs de
+                ces fables, et tous ceux qui exerçaient l’art de divertissement, c’est-à-dire l’art
+                des Histrions, et des Acteurs de la Scène, étaient si odieux aux anciens Romains,
+                qu’il y avait une loi parmi eux, qui défendait à ces sortes de gens de s’asseoir
+                dans les sièges des <pb n="376" xml:id="p376"/> quatorze premiers rangs. C’est ce
+                que témoigne Scipion dans ces livres que Cicéron a écrits de la République en ces
+                termes : <quote>« Les Romains estimant que l’art de divertissement, et tous les jeux
+                  de la Scène, étaient des choses honteuses, et infâmes, non seulement ils ont privé
+                  ces sortes de gens qui en sont les Acteurs, des honneurs, et des dignités dont la
+                  porte était ouverte aux autres Citoyens ; mais ils les ont même jugés dignes
+                  d’être notés par les Censeurs, pour être exclus de leurs tribus. Il faut donc
+                  bannir les Comédies des Théâtres. »</quote>. »</p></quote>
+
+            <p> Et dans le Livre 8. titre 14. <quote>« Il n’est point <seg type="exquote">,
+                  dit-il,</seg>
+                <note place="margin" resp="author"><quote>« Theatrorum ratio temporibus nostris
+                    minus necesaria est. Fabulæ enim omnes rejectæ, explosæque sunt, et severitate
+                    moris, religionisque sanctitate urbibus ejectæ ; quocirca supervacuum omnino
+                    esset, de statuendis Theatris plura dicere, cum vetera spectacula diruantur, et
+                    nova neutiquam ædificentur. »</quote> Idem lib. 8. tit. 14.</note> nécessaire de
+                parler des Théâtres dans le temps où nous sommes ; car la sévérité de nos mœurs ; et
+                la sainteté de notre Religion ont rejeté, et banni des villes toutes ces fables de
+                l’antiquité ; et il serait inutile de traiter plus au long de la structure des
+                Théâtres, puisqu’on les a démolis, et qu’on n’en bâtit point de nouveaux. » </quote>
             </p>
             <p>Nous voyons par là que dans le quinzième siècle les Tragédies, et les Comédies
               étaient condamnées. Ce qui détruit cette proposition fondamentale de la
@@ -16995,30 +16793,29 @@
             <p>Saint Charles Borromée Archevêque de Milan dans le troisième Synode Diocésain de
               Milan, tenu <pb n="378" xml:id="p378"/>l’an 1573. fit ce règlement sur l’obligation
               qu’ont les Prédicateurs de prêcher contre les Comédies, et les autres pernicieuses
-              coutumes, qui sont la source des péchés ; et de persuader de les abolir. <quote>« Que
-                les Prédicateurs<seg type="exquote">, dit-il<note place="margin" resp="author"><p>
-                      <quote>« Publicorum peccatorum illecebras, quas homines depravatæ
+              coutumes, qui sont la source des péchés ; et de persuader de les abolir. </p>
+            <quote><p>« Que les Prédicateurs<seg type="exquote">, dit-il<note place="margin"
+                    resp="author">
+                    <quote><p>« Publicorum peccatorum illecebras, quas homines depravatæ
                         consuetudinis errore decepti pro nihilo putant, Concionator perpetuo
                         reprehendet, atque in summum odium adducere contendet : ostendetque quam
                         graviter Deum offendant ; quam multa mala, atque adeo publicæ etiam
-                        calamitates, infinitaque detrimenta inde
-                        existant.</quote></p><p><quote>« Spectacula, ludos, ludicrasque res id
-                        generis quæ ad Ethnicorum moribus originem ducunt, disciplinæque Christianæ
-                        adversantur, perpetuo detestabitur, execrabitur : demonstrabit incommoda,
-                        publicasque inde ærumnas in populum Christianum
-                        dimanare.</quote></p><p><quote>« In quam sententiam valde populum
-                        confirmabit argumentis, quæ gravissimi viri, Tertullianus, Cyprianus Martyr,
-                        Salvianus, et Chrysostomus afferunt : in eoque argumenti genere, nullum
-                        aliud omittet, quo tanta corruptela radicitus extirpetur. Choreas,
-                        saltationes, ac tripudia, e quibus mortiferæ cupiditates excitantur, de
-                        suggestu sæpe graviter reprehendet, atque
-                        infectabitur.</quote></p><p><quote>« Scenicæ, personatæque actiones, unde
-                        tanquam e quodam seminario semina malefactorum, ac flagitiorum pene omnium
-                        existunt, quam a Christianæ disciplinæ officiis abhorrentes, quam valde cum
-                        Paganorum institutis convenientes, atque diaboli astu inventæ, omni officio
-                        a populo Christiano exterminandæ sint, qua maxima poterit religiosa
-                        contentione aget. »</quote></p><p>Statutum S. Caroli Borromæi, Ex Synodo
-                      Diœcesana Mediol.3. ann. 1572. in actor. part. 2.</p></note>,</seg> reprennent
+                        calamitates, infinitaque detrimenta inde existant.</p><p>Spectacula, ludos,
+                        ludicrasque res id generis quæ ad Ethnicorum moribus originem ducunt,
+                        disciplinæque Christianæ adversantur, perpetuo detestabitur, execrabitur :
+                        demonstrabit incommoda, publicasque inde ærumnas in populum Christianum
+                        dimanare.</p><p>In quam sententiam valde populum confirmabit argumentis, quæ
+                        gravissimi viri, Tertullianus, Cyprianus Martyr, Salvianus, et Chrysostomus
+                        afferunt : in eoque argumenti genere, nullum aliud omittet, quo tanta
+                        corruptela radicitus extirpetur. Choreas, saltationes, ac tripudia, e quibus
+                        mortiferæ cupiditates excitantur, de suggestu sæpe graviter reprehendet,
+                        atque infectabitur.</p><p>Scenicæ, personatæque actiones, unde tanquam e
+                        quodam seminario semina malefactorum, ac flagitiorum pene omnium existunt,
+                        quam a Christianæ disciplinæ officiis abhorrentes, quam valde cum Paganorum
+                        institutis convenientes, atque diaboli astu inventæ, omni officio a populo
+                        Christiano exterminandæ sint, qua maxima poterit religiosa contentione
+                        aget. »</p></quote><p>Statutum S. Caroli Borromæi, Ex Synodo Diœcesana
+                      Mediol.3. ann. 1572. in actor. part. 2.</p></note>,</seg> reprennent
                 continuellement les plaisirs publics qui portent aux péchés, auxquels les personnes
                 qui suivent le dérèglement d’une coutume dépravée se laissent emporter si
                 facilement, sans en considérer le mal ; Que les Prédicateurs s’efforcent de rendre
@@ -17028,21 +16825,19 @@
                 malheurs. Qu’ils représentent sans cesse combien les spectacles, les jeux, et les
                 autres divertissements semblables, qui sont des restes du Paganisme, sont contraires
                 à la discipline Chrétienne ; combien ils sont exécrables, et détestables, combien de
-                maux et d’afflictions publiques ils attirent sur le peuple Chrétien.</quote></p>
-            <p>
-              <quote>« Et pour en persuader leurs auditeurs, ils emploieront les raisons dont se
-                sont servis ces grands personnages, Tertullien, S. Cyprien Martyr, Salvien, et saint
-                Chrysostome : ils n’omettront rien sur ce sujet de ce qui peut contribuer à détruire
-                entièrement ces dérèglements, et ces débauches. Ils prêcheront souvent avec force
-                contre les Danses, et le Bal, par lequel sont excitées les passions les plus
-                dangereuses.</quote>
-            </p>
-            <p><quote>« Enfin ils emploieront tous leurs soins à représenter avec un zèle pieux, et
-                avec autant de véhémence qu’il leur sera possible, combien les Comédies,. et les
-                Mascarades, qui sont la source et la base presque de tous les maux, et de tous les
-                crimes, sont opposées aux devoirs de la discipline Chrétienne, et combien elles sont
-                conformes aux dérèglements des Païens, et que comme elles sont une pure invention de
-                la malice du démon, le peuple Chrétien les doit entièrement abolir »</quote></p>
+                maux et d’afflictions publiques ils attirent sur le peuple Chrétien.</p><p>Et pour
+                en persuader leurs auditeurs, ils emploieront les raisons dont se sont servis ces
+                grands personnages, Tertullien, S. Cyprien Martyr, Salvien, et saint Chrysostome :
+                ils n’omettront rien sur ce sujet de ce qui peut contribuer à détruire entièrement
+                ces dérèglements, et ces débauches. Ils prêcheront souvent avec force contre les
+                Danses, et le Bal, par lequel sont excitées les passions les plus
+                dangereuses.</p><p>Enfin ils emploieront tous leurs soins à représenter avec un zèle
+                pieux, et avec autant de véhémence qu’il leur sera possible, combien les Comédies,.
+                et les Mascarades, qui sont la source et la base presque de tous les maux, et de
+                tous les crimes, sont opposées aux devoirs de la discipline Chrétienne, et combien
+                elles sont conformes aux dérèglements des Païens, et que comme elles sont une pure
+                invention de la malice du démon, le peuple Chrétien les doit entièrement
+                abolir »</p></quote>
             <p>Ce règlement enjoignant aux Prédicateurs d’employer contre la Comédie les raisons
               dont Tertullien, S. Cyprien, Salvien, et S. Chrysostome se sont servis ; <pb n="379"
                 xml:id="p379"/>condamne formellement cette proposition fondamentale de la
@@ -17099,11 +16894,11 @@
                     11.</note>,</seg> comment peut-on accorder ces actions séculières qui flattent
                 les sens, et donnent du plaisir à la chair, avec les larmes d’une âme vraiment
                 pénitente, qui s’afflige pour rendre honneur à la Justice de Dieu, par la haine
-                qu’elle a conçue contre le péché, et contre elle-même ?</quote></p>
+                qu’elle a conçue contre le péché, et contre elle-même ? »</quote></p>
             <p>
               <quote>« Or le temps marqué pour la pénitence comprend les jours des Litanies, et des
                 Quatre temps, et tous les autres jours, dans lesquels les fidèles sont tenus de
-                jeûner...</quote>
+                jeûner... »</quote>
             </p>
             <p>
               <quote>« Concluons donc que ceux qui dansent, ou qui assistent aux Comédies dans le
@@ -17117,43 +16912,36 @@
               les jours de Fêtes, commettent un crime énorme. Il commence par la considération de
               l’institution du Dimanche, et des Fêtes, et des exercices qui sont propres à la
               sainteté de ces jours, afin de faire connaître par là que les Comédies sont
-              incompatibles avec ces dévotions, et avec ces solennités. <quote>« La fin
-                  principale<seg type="exquote">, dit-il<note place="margin" resp="author">S.
-                    Charles chap. 12.</note>,</seg> pour laquelle les Fêtes ont été instituées,
-                comme l’Ecriture même nous enseigne ; c’est pour honorer le repos ineffable de Dieu
-                après l’ouvrage de six jours : <quote>« Dieu a fait, <seg type="exquote">est-il dit
-                    dans l’Exode<note place="margin" resp="author"><quote>« Sex diebus fecit Dominus
-                        cœlum et terram, et mare, et omnia quæ in eis sunt, et requievit in die
-                        septimo : Idcirco benedixit Dominus diei Sabbati, et sanctificavit
-                        eum. »</quote> Exod. 10. v. 11.</note>,</seg> le ciel, la terre, la mer, et
-                  toutes les autres <pb n="381" xml:id="p381"/>choses qui y sont contenues ; et il
-                  s’est reposé le septième jour ; c’est pour cela qu’il a ordonné un jour de repos,
-                  qu’il l’a béni, et qu’il l’a sanctifié.  »</quote></quote></p>
-            <p>
-              <quote>« Nous devons donc en ces jours nous séparer des occupations temporelles, et
-                qui regardent le siècle, pour nous occuper en Dieu, et aux choses spirituelles : Et
-                c’est ce qu’on appelle sanctifier les Fêtes. Ce qui est encore expressément marqué
-                dans les livres des constitutions Apostoliques, qui nous apprennent que les jours de
-                Fêtes ne sont établis que pour le culte de Dieu</quote>
-              <note place="margin" resp="author">Constitut. Apostolic. lib. 7. cap. 31. et 37. et
-                lib. 8. cap. 32.</note>
-              <quote> ; et afin que nous nous souvenions de sa naissance dans la chair, de sa mort,
-                et de sa résurrection, et qu’étant remplis d’une joie toute spirituelle dans la vue
-                de ses inestimables bienfaits, nous l’honorions par des actions de grâces, et par
-                des œuvres de vertu.</quote>
-            </p>
-            <p>
-              <quote>« Outre le Dimanche nous célébrons encore des Fêtes en l’honneur des Saints ;
-                mais ce culte revient à la gloire du Fils de Dieu, qui en est le Chef ; parce que
-                c’est lui qui les a sanctifiés, et qui les ayant fait ses membres, leur a fait part
-                de la plénitude de son esprit, par laquelle ils sont devenus saints, et parfaits.
-                Nous célébrons encore ces mêmes Fêtes des Saints, afin que nous remettant dans
-                l’esprit la vie qu’ils ont menée, et les vertus qu’ils ont pratiquées avec tant de
-                fidélité, et de perfection, nous concevions des désirs solides de les imiter, et
-                nous résolvions à suivre leur exemple.</quote>
-            </p>
-            <p>
-              <quote>« C’est ce que S. Paul veut dire, lorsqu’il écrit aux Hébreux <note
+              incompatibles avec ces dévotions, et avec ces solennités. </p>
+            <quote><p>« La fin principale<seg type="exquote">, dit-il<note place="margin"
+                    resp="author">S. Charles chap. 12.</note>,</seg> pour laquelle les Fêtes ont été
+                instituées, comme l’Ecriture même nous enseigne ; c’est pour honorer le repos
+                ineffable de Dieu après l’ouvrage de six jours : <quote>« Dieu a fait, <seg
+                    type="exquote">est-il dit dans l’Exode<note place="margin" resp="author"
+                        ><quote>« Sex diebus fecit Dominus cœlum et terram, et mare, et omnia quæ in
+                        eis sunt, et requievit in die septimo : Idcirco benedixit Dominus diei
+                        Sabbati, et sanctificavit eum. »</quote> Exod. 10. v. 11.</note>,</seg> le
+                  ciel, la terre, la mer, et toutes les autres <pb n="381" xml:id="p381"/>choses qui
+                  y sont contenues ; et il s’est reposé le septième jour ; c’est pour cela qu’il a
+                  ordonné un jour de repos, qu’il l’a béni, et qu’il l’a sanctifié.
+                 »</quote></p><p>Nous devons donc en ces jours nous séparer des occupations
+                temporelles, et qui regardent le siècle, pour nous occuper en Dieu, et aux choses
+                spirituelles : Et c’est ce qu’on appelle sanctifier les Fêtes. Ce qui est encore
+                expressément marqué dans les livres des constitutions Apostoliques, qui nous
+                apprennent que les jours de Fêtes ne sont établis que pour le culte de Dieu <note
+                  place="margin" resp="author">Constitut. Apostolic. lib. 7. cap. 31. et 37. et lib.
+                  8. cap. 32.</note> ; et afin que nous nous souvenions de sa naissance dans la
+                chair, de sa mort, et de sa résurrection, et qu’étant remplis d’une joie toute
+                spirituelle dans la vue de ses inestimables bienfaits, nous l’honorions par des
+                actions de grâces, et par des œuvres de vertu.</p><p>Outre le Dimanche nous
+                célébrons encore des Fêtes en l’honneur des Saints ; mais ce culte revient à la
+                gloire du Fils de Dieu, qui en est le Chef ; parce que c’est lui qui les a
+                sanctifiés, et qui les ayant fait ses membres, leur a fait part de la plénitude de
+                son esprit, par laquelle ils sont devenus saints, et parfaits. Nous célébrons encore
+                ces mêmes Fêtes des Saints, afin que nous remettant dans l’esprit la vie qu’ils ont
+                menée, et les vertus qu’ils ont pratiquées avec tant de fidélité, et de perfection,
+                nous concevions des désirs solides de les imiter, et nous résolvions à suivre leur
+                exemple.</p><p>C’est ce que S. Paul veut dire, lorsqu’il écrit aux Hébreux <note
                   place="margin" resp="author"><quote>« Mementote Præpositorum vestrorum qui vobis
                     locuti sunt verbum Dei ; quorum intuentes exitum, conversationis imitamini
                     fidem. »</quote> Hebr. 13. v. 7.</note>  : <quote>« Souvenez-vous de vos
@@ -17161,8 +16949,8 @@
                   fin de leur sainte vie, imitez leur foi. »</quote> Car suivant l’interprétation de
                 Théodoret, l’Apôtre parle en cet endroit de ceux qui étaient déjà morts, comme S.
                 Jacques qu’il appelle ailleurs, le frère du Seigneur ; et qui avait été tué par le
-                commandement d’Hérode. »</quote>
-            </p>
+                commandement d’Hérode. »</p></quote>
+
             <p>Il confirme cette vérité touchant les devoirs des Chrétiens les jours de Fêtes, par
               les autorités de S. Basile, du Pape Nicolas I. du Pape Alexandre III. du Concile de
               Fréjus, du Concile de Mâcon<note place="margin" resp="author">S. Basil. in serm. de
@@ -17186,60 +16974,48 @@
             <p>Et comme il y a des Casuistes qui sont descendus dans un relâchement si étrange, que
               de réduire l’obligation de ne point danser, et de ne point assister aux spectacles les
               jours de Fêtes, au seul temps de la Messe ; ou bien des Offices Divins ; S. Charles
-              les reprend avec une force et un zèle tout Apostolique : <quote>« C’est<seg
-                  type="exquote">, dit-il<note place="margin" resp="author">S. Charles chap.
-                    11.</note>,</seg> ce qui a donné fondement aux abus déplorables, et aux
-                désordres qu’on voit partout sur ce sujet, en ces saints jours. Ces Casuistes
+              les reprend avec une force et un zèle tout Apostolique : </p>
+            <quote><p>« C’est<seg type="exquote">, dit-il<note place="margin" resp="author">S.
+                    Charles chap. 11.</note>,</seg> ce qui a donné fondement aux abus déplorables,
+                et aux désordres qu’on voit partout sur ce sujet, en ces saints jours. Ces Casuistes
                 eussent bien mieux fait de suivre constamment et de soutenir généreusement la
                 doctrine des Anciens, appuyée sur la discipline de l’Eglise et animée de son esprit,
                 et de réprimer par la force de la vérité, la licence effrénée des Chrétiens
                 relâchés, et vicieux, que de leur apprendre une voie large, qui favorise leurs
                 convoitises, et qui par conséquent ne peut que les conduire au précipice, par des
                 opinions nouvelles, qui n’ont aucun fondement dans la doctrine de l’Eglise, ni dans
-                celle des Saints...</quote></p>
-            <p>
-              <quote>« Ces Casuistes ont fait tort à la vérité <note place="margin" resp="author"
-                  >Idem chap. 14.</note> , et ils ont été trop hardis de vouloir limiter ainsi par
-                leurs interprétations particulières, l’obligation que les Canons imposent sans
-                restriction aux fidèles. Ces Auteurs ont eu sans doute plus d’égard dans cette
-                occasion à l’usage commun de leur temps, qu’à la vérité et à l’esprit de
-                l’Eglise.</quote>
-            </p>
-            <p>
-              <quote>« Je dis donc que lorsque les Conciles ont défendu la danse <pb n="383"
-                  xml:id="p383"/> et les spectacles dans le temps des Divins Offices, ils ont jugé
-                qu’on ne pouvait pas dans un même jour, vaquer aux Divins Offices, et s’adonner aux
-                divertissements du monde. Car encore bien que par le refroidissement de la charité,
-                et de la piété Chrétienne, les fidèles commencent maintenant, à donner moins de
-                temps à ces actions saintes, et à demeurer moins assemblés dans les lieux Saints ;
-                Il est néanmoins constant que suivant l’usage des siècles passés, et suivant la
-                discipline ancienne de l’Eglise, les jours de Fêtes étaient presque entièrement
-                occupés par les exercices spirituels qui se faisaient dans les Eglises. En effet ne
-                voit-on pas dans la lecture des Pères, que les Messes solennelles, les lectures
-                saintes, les psalmodies, les exhortations, et les sermons, ne donnaient point le
-                loisir aux Chrétiens de vaquer à quelque autre chose, mais les obligeaient d’être
-                continuellement dans les lieux Saints ?</quote>
-            </p>
-            <p>
-              <quote>« C’est ce que nous font comprendre ces admirables paroles du Concile de Mâcon
-                  <note place="margin" resp="author"><quote>« Sint oculi, manusque vestræ toto die
-                    Dominico ad Deum expansæ. »</quote> Concil. Matisconense 2. can. 1.</note>  :
-                  <quote>« Que le Dimanche vos yeux, et vos mains soient élevés vers Dieu durant
-                  tout le jour.  »</quote></quote>
-            </p>
-            <p>
-              <quote>« Je dis bien davantage, il est impossible que cette occupation continuelle aux
-                choses de Dieu, pendant les jours de Fêtes, ne se trouve par tous les lieux où l’on
-                travaille sérieusement à rétablir le culte Divin : car les Heures Canoniales, la
-                solennité des Messes, la doctrine chrétienne commandée par le Concile de Trente, et
-                les sermons remplissent toute la journée. </quote>
-            </p>
-            <p>
-              <quote>« Et quand même les Offices Divins, et les exercices pour lesquels les fidèles
-                s’assemblent ne rempliraient pas entièrement le temps ; les constitutions de
-                l’Eglise ne permettraient pas néanmoins, qu’on l’employât aux jeux, et à la danse ;
-                parce que la raison principale, et fondamentale, pour laquelle on doit retrancher
-                ces divertissements subsiste toujours, qui est l’obligation de sanctifier les Fêtes,
+                celle des Saints... </p><p>Ces Casuistes ont fait tort à la vérité <note
+                  place="margin" resp="author">Idem chap. 14.</note> , et ils ont été trop hardis de
+                vouloir limiter ainsi par leurs interprétations particulières, l’obligation que les
+                Canons imposent sans restriction aux fidèles. Ces Auteurs ont eu sans doute plus
+                d’égard dans cette occasion à l’usage commun de leur temps, qu’à la vérité et à
+                l’esprit de l’Eglise.</p><p>Je dis donc que lorsque les Conciles ont défendu la
+                danse <pb n="383" xml:id="p383"/> et les spectacles dans le temps des Divins
+                Offices, ils ont jugé qu’on ne pouvait pas dans un même jour, vaquer aux Divins
+                Offices, et s’adonner aux divertissements du monde. Car encore bien que par le
+                refroidissement de la charité, et de la piété Chrétienne, les fidèles commencent
+                maintenant, à donner moins de temps à ces actions saintes, et à demeurer moins
+                assemblés dans les lieux Saints ; Il est néanmoins constant que suivant l’usage des
+                siècles passés, et suivant la discipline ancienne de l’Eglise, les jours de Fêtes
+                étaient presque entièrement occupés par les exercices spirituels qui se faisaient
+                dans les Eglises. En effet ne voit-on pas dans la lecture des Pères, que les Messes
+                solennelles, les lectures saintes, les psalmodies, les exhortations, et les sermons,
+                ne donnaient point le loisir aux Chrétiens de vaquer à quelque autre chose, mais les
+                obligeaient d’être continuellement dans les lieux Saints ?</p><p>C’est ce que nous
+                font comprendre ces admirables paroles du Concile de Mâcon <note place="margin"
+                  resp="author"><quote>« Sint oculi, manusque vestræ toto die Dominico ad Deum
+                    expansæ. »</quote> Concil. Matisconense 2. can. 1.</note>  : <quote>« Que le
+                  Dimanche vos yeux, et vos mains soient élevés vers Dieu durant tout le jour.
+                   »</quote></p><p>Je dis bien davantage, il est impossible que cette occupation
+                continuelle aux choses de Dieu, pendant les jours de Fêtes, ne se trouve par tous
+                les lieux où l’on travaille sérieusement à rétablir le culte Divin : car les Heures
+                Canoniales, la solennité des Messes, la doctrine chrétienne commandée par le Concile
+                de Trente, et les sermons remplissent toute la journée.</p><p>Et quand même les
+                Offices Divins, et les exercices pour lesquels les fidèles s’assemblent ne
+                rempliraient pas entièrement le temps ; les constitutions de l’Eglise ne
+                permettraient pas néanmoins, qu’on l’employât aux jeux, et à la danse ; parce que la
+                raison principale, et fondamentale, pour laquelle on doit retrancher ces
+                divertissements subsiste toujours, qui est l’obligation de sanctifier les Fêtes,
                 établies dans la Loi de Dieu même. Car quoique les assemblées des Chrétiens dans les
                 Eglises, soient des moyens qui servent excellemment à cette sanctification, s’il
                 arrive toutefois qu’elles aient cessé en partie en quelques lieux, par le <pb
@@ -17255,64 +17031,54 @@
                       Nicol. Pap. 1. in R[esponsione] ad Bulgar. cap. 11.</note>, </seg> les jours
                   de Fêtes de toutes les affaires séculières, afin que les Chrétiens puissent plus
                   librement se trouver aux Eglises, et passer les saints jours en prières, et dans
-                  le chant des Psaumes, des Hymnes, et des Cantiques spirituels. »</quote></quote>
-            </p>
-            <p>
-              <quote>« Il est donc évident par l’autorité de ce Pape, et de plusieurs autres, que le
-                fondement général de toutes les prohibitions qui regardent la solennité des Fêtes,
-                est l’obligation de les sanctifier, laquelle nous est imposée dans l’Ecriture
-                sainte, et par le Commandement de Dieu même.</quote>
-            </p>
-            <p>
-              <quote>« Ce qui est invinciblement confirmé par les lois des Empereurs que nous avons
-                citées, dans lesquelles les Princes zélés pour la gloire de Dieu, défendent comme un
-                crime, de s’adonner les jours de Fêtes aux exercices qui servent à la volupté, et au
-                plaisir par la considération de cette même obligation que les Chrétiens ont de
-                s’appliquer uniquement au culte de Dieu, et de travailler à leur propre
-                sanctification. <quote>« Nous défendons <seg type="exquote">, disent-ils <note
-                      place="margin" resp="author"><quote>« Omni Theatrorum, atque Circensium
-                        voluptate per universas urbes earum populis denegata, totæ Christianorum, ac
-                        fidelium mentes Dei cultibus occupentur…. Aliud esse supplicationum noverint
-                        tempus, aliud voluptatum. »</quote> In cod. Theodos. lib. 15. tit. 5. l. 5.
-                        <quote>« Dies festos majestati altissimæ dedicatos nullis volumis
-                        voluptatibus occupari. »</quote> L. ult. cod. de feriis.</note>,</seg> au
-                  peuple de toutes les villes de notre Empire, tous les divertissements du Théâtre
-                  et du Cirque, les jours de Fêtes, afin que les Fidèles occupent tout leur cœur et
-                  tout leur esprit au service de Dieu....et qu’ils reconnaissent que le temps des
-                  prières est bien différent du temps des divertissements et des plaisirs. Nous ne
-                  voulons point que les jours de Fêtes, qui sont dédiés à la souveraine majesté de
-                  Dieu, soient employés aux voluptés, et aux divertissements en aucune
-                  manière. »</quote></quote>
-            </p>
-            <p>
-              <quote>« Puis donc que les Empereurs ont si absolument défendu toute sorte de jeux, de
-                divertissements séculiers, et de plaisirs sensuels, afin que le peuple fidèle
-                sanctifiât les Fêtes, et vaquât de tout son cœur aux choses de Dieu ; ce serait <pb
-                  n="385" xml:id="p385"/> faire injure à l’autorité sacerdotale, et à la puissance
-                Ecclésiastique, de penser que des saints Evêques eussent été moins exacts qu’eux
-                dans leurs Ordonnances sur ce sujet, principalement lorsque nous voyons qu’ils ne
-                parlent jamais dans leurs écrits des jeux, et des spectacles, qu’avec horreur, et
-                avec exécration...</quote>
-            </p>
-            <p>
-              <quote>« Il paraît donc clairement que les spectacles, les jeux, et les danses sont
-                illicites, au moins en ces saints jours ; et que l’opinion de ceux qui restreignent
-                la prohibition, de ces choses au temps des divins offices doit être rejetée, comme
-                une invention de l’esprit humain, et particulier… Il est constant que le bal et
-                les danses sont incompatibles avec la sanctification des Fêtes : et que toutes
-                sortes de jeux, et spectacles sont défendus en ces mêmes jours par les lois
-                Ecclésiastiques, et civiles. D’où il s’ensuit sur le principe commun, et reçu de
-                tout le monde, que celui-là pèche mortellement, qui en ces saints jours emploie
-                injustement le temps en ces sortes d’exercices ; si ce n’est que l’ignorance et le
-                sentiment relâché de ceux qui lui donnent conseil, et qui le conduisent, puisse
-                diminuer sa faute : ce que Dieu n’a jamais promis. »</quote>
-            </p>
+                  le chant des Psaumes, des Hymnes, et des Cantiques spirituels. »</quote></p><p>Il
+                est donc évident par l’autorité de ce Pape, et de plusieurs autres, que le fondement
+                général de toutes les prohibitions qui regardent la solennité des Fêtes, est
+                l’obligation de les sanctifier, laquelle nous est imposée dans l’Ecriture sainte, et
+                par le Commandement de Dieu même.</p><p>Ce qui est invinciblement confirmé par les
+                lois des Empereurs que nous avons citées, dans lesquelles les Princes zélés pour la
+                gloire de Dieu, défendent comme un crime, de s’adonner les jours de Fêtes aux
+                exercices qui servent à la volupté, et au plaisir par la considération de cette même
+                obligation que les Chrétiens ont de s’appliquer uniquement au culte de Dieu, et de
+                travailler à leur propre sanctification. <quote>« Nous défendons <seg type="exquote"
+                    >, disent-ils <note place="margin" resp="author"><quote>« Omni Theatrorum, atque
+                        Circensium voluptate per universas urbes earum populis denegata, totæ
+                        Christianorum, ac fidelium mentes Dei cultibus occupentur…. Aliud esse
+                        supplicationum noverint tempus, aliud voluptatum. »</quote> In cod. Theodos.
+                      lib. 15. tit. 5. l. 5. <quote>« Dies festos majestati altissimæ dedicatos
+                        nullis volumis voluptatibus occupari. »</quote> L. ult. cod. de
+                      feriis.</note>,</seg> au peuple de toutes les villes de notre Empire, tous les
+                  divertissements du Théâtre et du Cirque, les jours de Fêtes, afin que les Fidèles
+                  occupent tout leur cœur et tout leur esprit au service de Dieu....et qu’ils
+                  reconnaissent que le temps des prières est bien différent du temps des
+                  divertissements et des plaisirs. Nous ne voulons point que les jours de Fêtes, qui
+                  sont dédiés à la souveraine majesté de Dieu, soient employés aux voluptés, et aux
+                  divertissements en aucune manière. »</quote></p><p>Puis donc que les Empereurs ont
+                si absolument défendu toute sorte de jeux, de divertissements séculiers, et de
+                plaisirs sensuels, afin que le peuple fidèle sanctifiât les Fêtes, et vaquât de tout
+                son cœur aux choses de Dieu ; ce serait <pb n="385" xml:id="p385"/> faire injure à
+                l’autorité sacerdotale, et à la puissance Ecclésiastique, de penser que des saints
+                Evêques eussent été moins exacts qu’eux dans leurs Ordonnances sur ce sujet,
+                principalement lorsque nous voyons qu’ils ne parlent jamais dans leurs écrits des
+                jeux, et des spectacles, qu’avec horreur, et avec exécration...</p><p>Il paraît donc
+                clairement que les spectacles, les jeux, et les danses sont illicites, au moins en
+                ces saints jours ; et que l’opinion de ceux qui restreignent la prohibition, de ces
+                choses au temps des divins offices doit être rejetée, comme une invention de
+                l’esprit humain, et particulier… Il est constant que le bal et les danses sont
+                incompatibles avec la sanctification des Fêtes : et que toutes sortes de jeux, et
+                spectacles sont défendus en ces mêmes jours par les lois Ecclésiastiques, et
+                civiles. D’où il s’ensuit sur le principe commun, et reçu de tout le monde, que
+                celui-là pèche mortellement, qui en ces saints jours emploie injustement le temps en
+                ces sortes d’exercices ; si ce n’est que l’ignorance et le sentiment relâché de ceux
+                qui lui donnent conseil, et qui le conduisent, puisse diminuer sa faute : ce que
+                Dieu n’a jamais promis. »</p></quote>
+
             <p>Après il montre que les raisons qui rendent les Danses, et les Comédies criminelles,
               se rencontrent dans celles d’aujourd’hui ; de sorte qu’on peut dire avec vérité que
               c’est une invention du diable, pour perdre les âmes, et pour corrompre les mœurs des
               Fidèles. Que les assemblées qui se font pour ces divertissements, sont si dangereuses,
-              qu’il n’y a point de doute qu’un Chrétien ne soit obligé de les fuir.
-                  <quote>« C’est<seg type="exquote">, dit-il<note place="margin" resp="author">S.
+              qu’il n’y a point de doute qu’un Chrétien ne soit obligé de les fuir.</p>
+            <quote><p>« C’est<seg type="exquote">, dit-il<note place="margin" resp="author">S.
                     Charles chap. 16.</note>,</seg> un principe incontestable qu’on ne peut se
                 mettre dans le danger de pécher, sans blesser sa conscience ; et qu’on est
                 indispensablement obligé de fuir toutes les occasions qui peuvent porter au mal.
@@ -17320,46 +17086,40 @@
                   votre œil<seg type="exquote">, dit-il<note place="margin" resp="author"
                         ><quote>« Si oculus tuus scandalizat te, erue eum, et projice abs
                         te. »</quote> Math. 5. v. 29.</note></seg>, vous est un sujet de scandale,
-                  arrachez-le, et jetez-le loin de vous. »  »</quote></quote></p>
-            <p>
-              <quote>« Ajoutez à cela ce que Notre Seigneur dit lui-même <note place="margin"
-                  resp="author"><quote>« Qui viderit mulierem ad concupiscendum illam, jam mœchatus
-                    est eam in corde suo. »</quote> Ibid. v. 28.</note>  : <quote>« Que quiconque
-                  regardera une femme avec un <pb n="386" xml:id="p386"/> mauvais désir pour elle, a
-                  déjà commis l’adultère dans son cœur. »</quote></quote>
-            </p>
-            <p>
-              <quote>« Ces principes étant ainsi établis, considérons le mélange qui se fait dans le
-                Bal, et à la Comédie, d’hommes et de femmes : ils y sont assis les uns auprès des
-                autres, et n’y sont que pour se satisfaire ; ils se regardent réciproquement ; et
-                les yeux qui ne sont animés que de la curiosité, n’y trouvent que trop d’attraits
-                malins pour éveiller les sentiments de la chair corrompue : tout ce qu’on y voit, et
-                qu’on y entend, est tout propre pour émouvoir, et pour attendrir. On s’y entretient
-                familièrement ; on y vient fort ajusté et avec pompe ; les femmes et les filles y
-                sont parées comme des temples ; et il n’y a point d’ornement, ni d’invention
-                qu’elles n’emploient pour paraître belles, et pour se rendre agréables… Ceux qui
-                vont en ces lieux sont des personnes qui suivent le grand chemin, c’est-à-dire, le
-                train ordinaire, et l’esprit du monde ; comment pourraient-ils donc être dans ces
-                assemblées sans danger ? Après toutes ces considérations n’avouera-t-on pas que nous
-                avons sujet de dire, qu’on ne peut point se trouver dans ces assemblées avec sûreté
-                de conscience; et que le danger d’offenser Dieu y est évident, non seulement pour
-                ceux qui mènent une vie plus libre, et suivant le cours du monde ; mais encore pour
-                les plus chastes, et pour les mieux réglés...</quote>
-            </p>
-            <p>
-              <quote>« N’est-ce pas une chose étonnante et digne de larmes, de voir que les
-                Chrétiens qui sont obligés à une vie si pure et si sainte, se jettent eux-mêmes dans
-                les lacets du diable, et du monde ; et s’exposent hardiment, et sans aucune crainte
-                dans les périls effroyables du péché, sans faire aucun cas ni des avertissements du
-                saint Esprit, ni de la gloire de Dieu, ni de leur propre salut ! Qu’on ne nous croie
-                donc point trop sévères, si dans un siècle si corrompu, et dans l’état où sont les
-                Bals, les Danses et les Comédies de ce temps, nous n’osons point excuser de péché,
-                ceux qui les fréquentent, puisqu’Alexandre de Halès auteur célèbre, et recommandable
-                par sa doctrine, et par sa piété, n’ose point exempter de péché mortel</quote>
-              <note place="margin" resp="author">part. 4. 9. 8.</note>
-              <quote>, ceux qui n’étant venus que comme forcés, ou par rencontre dans ces assemblés,
-                  <pb n="387" xml:id="p387"/> s’y arrêtent avec danger d’y concevoir quelque mauvais
-                désir, et d’être touchés de quelque affection dangereuse. Et il n’y a point d’hommes
+                  arrachez-le, et jetez-le loin de vous. »</quote></p><p>Ajoutez à cela ce que Notre
+                Seigneur dit lui-même <note place="margin" resp="author"><quote>« Qui viderit
+                    mulierem ad concupiscendum illam, jam mœchatus est eam in corde suo. »</quote>
+                  Ibid. v. 28.</note>  : <quote>« Que quiconque regardera une femme avec un <pb
+                    n="386" xml:id="p386"/> mauvais désir pour elle, a déjà commis l’adultère dans
+                  son cœur. »</quote></p><p>Ces principes étant ainsi établis, considérons le
+                mélange qui se fait dans le Bal, et à la Comédie, d’hommes et de femmes : ils y sont
+                assis les uns auprès des autres, et n’y sont que pour se satisfaire ; ils se
+                regardent réciproquement ; et les yeux qui ne sont animés que de la curiosité, n’y
+                trouvent que trop d’attraits malins pour éveiller les sentiments de la chair
+                corrompue : tout ce qu’on y voit, et qu’on y entend, est tout propre pour émouvoir,
+                et pour attendrir. On s’y entretient familièrement ; on y vient fort ajusté et avec
+                pompe ; les femmes et les filles y sont parées comme des temples ; et il n’y a point
+                d’ornement, ni d’invention qu’elles n’emploient pour paraître belles, et pour se
+                rendre agréables… Ceux qui vont en ces lieux sont des personnes qui suivent le grand
+                chemin, c’est-à-dire, le train ordinaire, et l’esprit du monde ; comment
+                pourraient-ils donc être dans ces assemblées sans danger ? Après toutes ces
+                considérations n’avouera-t-on pas que nous avons sujet de dire, qu’on ne peut point
+                se trouver dans ces assemblées avec sûreté de conscience; et que le danger
+                d’offenser Dieu y est évident, non seulement pour ceux qui mènent une vie plus
+                libre, et suivant le cours du monde ; mais encore pour les plus chastes, et pour les
+                mieux réglés...</p><p>N’est-ce pas une chose étonnante et digne de larmes, de voir
+                que les Chrétiens qui sont obligés à une vie si pure et si sainte, se jettent
+                eux-mêmes dans les lacets du diable, et du monde ; et s’exposent hardiment, et sans
+                aucune crainte dans les périls effroyables du péché, sans faire aucun cas ni des
+                avertissements du saint Esprit, ni de la gloire de Dieu, ni de leur propre salut !
+                Qu’on ne nous croie donc point trop sévères, si dans un siècle si corrompu, et dans
+                l’état où sont les Bals, les Danses et les Comédies de ce temps, nous n’osons point
+                excuser de péché, ceux qui les fréquentent, puisqu’Alexandre de Halès auteur
+                célèbre, et recommandable par sa doctrine, et par sa piété, n’ose point exempter de
+                péché mortel <note place="margin" resp="author">part. 4. 9. 8.</note>, ceux qui
+                n’étant venus que comme forcés, ou par rencontre dans ces assemblés, <pb n="387"
+                  xml:id="p387"/> s’y arrêtent avec danger d’y concevoir quelque mauvais désir, et
+                d’être touchés de quelque affection dangereuse. Et il n’y a point d’hommes
                 raisonnables qui n’entrent dans ce sentiment, s’ils considèrent sans préoccupation,
                 et devant Dieu, avec quelle facilité les hommes et les femmes du monde tombent dans
                 des péchés intérieurs, c’est-à-dire de pensée et d’affection, et combien peu
@@ -17367,68 +17127,57 @@
                 lorsqu’ils y sont tombés. Le mal va si avant par une négligence criminelle, qu’il
                 s’en trouve plusieurs, qui ne font aucun scrupule des pensées déréglées, que leur
                 esprit reçoit avec agrément, ni des délectations sensuelles, et honteuses, dans
-                lesquelles ils s’entretiennent...</quote>
-            </p>
-            <p>
-              <quote>« Il n’est pas à propos de nous en expliquer davantage, ni encore de nous
-                étendre sur cet abus déplorable, qui n’est que trop connu, et qui fait gémir toutes
-                les bonnes âmes ; Je veux dire sur cette coutume malheureuse de perdre le temps le
-                plus saint, et les jours qui sont consacrés à la piété, dans les divertissements
-                mondains, et profanes. Hélas n’est-ce pas une chose lamentable, de voir qu’un si
-                grand nombre de Chrétiens emploient les Fêtes, et les Dimanches, surtout depuis la
-                Septuagésime, jusqu’à Carême, au jeu, au Bal, à la Danse, et à la Comédie, ou à voir
-                ou donner d’autres semblables spectacles, d’une manière très indigne, et pour ne pas
-                dire avec impiété, ou au moins avec un mépris intolérable des Canons de l’Eglise,
-                des Ordonnances des Princes, et de la loi de Dieu même, qui nous oblige de passer
-                les Fêtes saintement ?</quote>
-            </p>
-            <p>
-              <quote>« Est-il possible que l’on tolère dans l’Eglise de Dieu un libertinage si
-                horrible <note place="margin" resp="author">S. Charles chap. 17.</note> , et que
-                l’on voie des écoles publiques de lubricité, et des assemblés, où se font des
-                trafics infâmes, et où se concluent les desseins des impuretés les plus abominables,
-                et des adultères mêmes, les jours de Dimanches, et de Fêtes ; et encore plus
-                particulièrement dans le temps que l’Eglise a destiné pour remercier Dieu du
-                bienfait inestimable de la naissance de son fils, et depuis la Septuagésime jusqu’au
-                Carême ; c’est-à-dire, lorsque suivant l’intention de cette même Eglise nous
-                devrions être <pb n="388" xml:id="p388"/> occupés à pleurer nos péchés, et à nous
-                disposer à obtenir la grâce d’une parfaite pénitence. »</quote>
-            </p>
+                lesquelles ils s’entretiennent...</p><p>Il n’est pas à propos de nous en expliquer
+                davantage, ni encore de nous étendre sur cet abus déplorable, qui n’est que trop
+                connu, et qui fait gémir toutes les bonnes âmes ; Je veux dire sur cette coutume
+                malheureuse de perdre le temps le plus saint, et les jours qui sont consacrés à la
+                piété, dans les divertissements mondains, et profanes. Hélas n’est-ce pas une chose
+                lamentable, de voir qu’un si grand nombre de Chrétiens emploient les Fêtes, et les
+                Dimanches, surtout depuis la Septuagésime, jusqu’à Carême, au jeu, au Bal, à la
+                Danse, et à la Comédie, ou à voir ou donner d’autres semblables spectacles, d’une
+                manière très indigne, et pour ne pas dire avec impiété, ou au moins avec un mépris
+                intolérable des Canons de l’Eglise, des Ordonnances des Princes, et de la loi de
+                Dieu même, qui nous oblige de passer les Fêtes saintement ?</p><p>Est-il possible
+                que l’on tolère dans l’Eglise de Dieu un libertinage si horrible <note
+                  place="margin" resp="author">S. Charles chap. 17.</note> , et que l’on voie des
+                écoles publiques de lubricité, et des assemblés, où se font des trafics infâmes, et
+                où se concluent les desseins des impuretés les plus abominables, et des adultères
+                mêmes, les jours de Dimanches, et de Fêtes ; et encore plus particulièrement dans le
+                temps que l’Eglise a destiné pour remercier Dieu du bienfait inestimable de la
+                naissance de son fils, et depuis la Septuagésime jusqu’au Carême ; c’est-à-dire,
+                lorsque suivant l’intention de cette même Eglise nous devrions être <pb n="388"
+                  xml:id="p388"/> occupés à pleurer nos péchés, et à nous disposer à obtenir la
+                grâce d’une parfaite pénitence. »</p></quote>
+
             <p>Et sur ce que quelques-uns disent que les assemblées du Bal, et de la Comédie donnent
               souvent occasion à beaucoup de mariages, qui ne se contracteraient jamais autrement ;
               d’où ils concluent que ces assemblées non seulement ne sont pas mauvaises, et
               illicites ; mais qu’elles sont même quelquefois utiles ; voici ce que répond ce grand
-                Saint<note place="margin" resp="author">S. Charles chap. 18.</note>. <quote>« O
-                aveuglement des hommes ! ô étranges mariages, dont le dessein n’est conçu que dans
-                la recherche de la volupté, et ne peut naître que des sentiments de la chair,
-                puisque ce qu’on voit et qu’on entend dans la Danse et dans la Comédie en inspire
-                les pensées ? Craindra-t-on bien que ces hommes, et ces filles ne trouvent point des
-                occasions de se marier, s’ils ne se servent des moyens vicieux, ou dangereux pour
-                rencontrer un parti ? Mais peut-on espérer que Dieu donnera bénédiction à des
-                alliances qui prennent leur naissance des principes si corrompus, et si opposés à
-                son esprit ? O aveuglement des hommes !</quote></p>
-            <p>
-              <quote>« Hélas pourquoi ne fait-on mention que des mariages qui se contractent sur le
-                fondement des affections sensuelles qui ont été conçues dans le Bal, et à la
-                Comédie ? N’est-il pas juste qu’on compare avec ce bien imaginaire, qui traîne
-                presque toujours après soi une longue fuite de maux de toute espèce, les desseins si
-                abominables de tant d’impuretés et de tant d’adultères qui se forment dans ces mêmes
-                lieux ? Ne compte-t-on pour rien tant de pensées impures, et tant de mauvais désirs,
-                dont les âmes qui étaient peut-être venues pures au Bal, et à la Comédie, se
-                trouvent toutes salies et noircies lorsqu’elles en sortent ? Comment peut-on donc
-                excuser une pratique si remplie de véritables maux, sous prétexte d’un bien
-                apparent ?</quote>
-            </p>
-            <p>
-              <quote>« Mais il est temps de finir ce Traité, et de ne penser plus qu’à gémir, et à
-                prier la bonté toute puissante de Dieu, de donner en ceux qui sont constitués en
-                dignités, et en charge pour régir les peuples, et la lumière pour donner les remèdes
-                convenables, afin d’ôter un abus si <pb n="389" xml:id="p389"/> insupportable, et
-                néanmoins si commun ; et le zèle de la gloire de Dieu, et du salut des âmes, afin
-                d’en bien faire l’application, avec grâces, et avec fruit.</quote>
-            </p>
-            <p>
-              <quote>« Ceux qui sont en autorité pour gouverner les peuples ne sont pas moins
+                Saint<note place="margin" resp="author">S. Charles chap. 18.</note>. </p>
+            <quote><p>« O aveuglement des hommes ! ô étranges mariages, dont le dessein n’est conçu
+                que dans la recherche de la volupté, et ne peut naître que des sentiments de la
+                chair, puisque ce qu’on voit et qu’on entend dans la Danse et dans la Comédie en
+                inspire les pensées ? Craindra-t-on bien que ces hommes, et ces filles ne trouvent
+                point des occasions de se marier, s’ils ne se servent des moyens vicieux, ou
+                dangereux pour rencontrer un parti ? Mais peut-on espérer que Dieu donnera
+                bénédiction à des alliances qui prennent leur naissance des principes si corrompus,
+                et si opposés à son esprit ? O aveuglement des hommes !</p><p>Hélas pourquoi ne
+                fait-on mention que des mariages qui se contractent sur le fondement des affections
+                sensuelles qui ont été conçues dans le Bal, et à la Comédie ? N’est-il pas juste
+                qu’on compare avec ce bien imaginaire, qui traîne presque toujours après soi une
+                longue fuite de maux de toute espèce, les desseins si abominables de tant
+                d’impuretés et de tant d’adultères qui se forment dans ces mêmes lieux ? Ne
+                compte-t-on pour rien tant de pensées impures, et tant de mauvais désirs, dont les
+                âmes qui étaient peut-être venues pures au Bal, et à la Comédie, se trouvent toutes
+                salies et noircies lorsqu’elles en sortent ? Comment peut-on donc excuser une
+                pratique si remplie de véritables maux, sous prétexte d’un bien
+                apparent ?</p><p>Mais il est temps de finir ce Traité, et de ne penser plus qu’à
+                gémir, et à prier la bonté toute puissante de Dieu, de donner en ceux qui sont
+                constitués en dignités, et en charge pour régir les peuples, et la lumière pour
+                donner les remèdes convenables, afin d’ôter un abus si <pb n="389" xml:id="p389"
+                />insupportable, et néanmoins si commun ; et le zèle de la gloire de Dieu, et du
+                salut des âmes, afin d’en bien faire l’application, avec grâces, et avec
+                fruit.</p><p>Ceux qui sont en autorité pour gouverner les peuples ne sont pas moins
                 coupables <note place="margin" resp="author">chap. 16.</note> , lorsqu’ils ne
                 travaillent point à détruire cet abus, et qu’ils ne donnent aucun secours aux âmes
                 qui leur sont commises, pour les retirer de ces pratiques dangereuses, et de ces
@@ -17437,8 +17186,8 @@
                 Ecclésiastiques qui sont en charge. Et la négligence des Magistrats séculiers, qui
                 voient le mal, et n’y remédient pas, oblige encore plus étroitement les Prélats de
                 mettre les mains à l’œuvre <note place="margin" resp="author">chap. 19.</note> , et
-                de suppléer à leur défaut par leur zèle et par leur autorité. »</quote>
-            </p>
+                de suppléer à leur défaut par leur zèle et par leur autorité. »</p></quote>
+
             <p>On a joint au Traité de saint Charles Borromée contre les Danses, et les Comédies,
               une lettre que l’Evêque d’Agnani écrivit au Pape Paul V. le 18. Mai, l’an 1600. pour
               la défense d’une Ordonnance synodale, par laquelle il avait défendu les Danses, et les
@@ -17461,7 +17210,7 @@
                 de ses saints, afin de suivre leurs exemples, afin d’implorer tous les ans leur
                 protection, et de vaquer à la prière en honorant leur mémoire et non pas afin de
                 passer ces saints jours dans l’oisiveté, dans les jeux, et dans les
-                divertissements...</quote></p>
+                divertissements... »</quote></p>
             <p>
               <quote>« Que les Recteurs donc, et les Pasteurs des Eglises exhortent les peuples qui
                 leur sont commis, d’être assidus à l’Eglise, pour y entendre dévotement le service
@@ -17544,7 +17293,7 @@
               <quote>« Que les Ecclésiastiques <seg type="exquote">, dit le Concile d’Aix tenu l’an
                   1585 <note place="margin" resp="author"><quote>« Nec personati unquam incedant
                       Clerici ; neve Comœdiarum, aut Chorearum, aut profani ullius spectaculi
-                      actores sint, vel spectatores</quote>. » Concil. Aquense an.
+                      actores sint, vel spectatores. »</quote> Concil. Aquense an.
                   1585.</note>.</seg> ne se masquent jamais : et ne soient ni acteurs, ni
                 spectateurs des Comédies, ni des danses, ni d’aucun autre Spectacle
                 profane. »</quote>
@@ -17572,48 +17321,46 @@
             </p>
             <p>Le Père Ribera dans ses Commentaires sur le Prophète <hi rend="i">Michée</hi>, a fait
               un excellent discours contre les Romans, et les Comédies de ce siècle : sur ces
-              paroles du Prophète : <quote>« Il donnera des Emissaires contre l’héritage de
-                Geth »</quote> "</p>
-            <p>
-              <quote>« Ceux qui donnent des Emissaires au Roi des Assyriens<note place="margin"
-                  resp="author"><p><quote>« At non illi Emissarios dant Regi Assyriorum, id est,
-                      diabolo, qui prodigi ingenii sui, atque otii ac nequitiæ suæ Poëtæ peccatum
-                      suum velut Sodoma, prædicantes, amatoria, et lasciva carmina scribunt, perinde
-                      ac si Ethnici essent, a quibus cum sensu, et voluntate non admodum
-                      discreperit, lætantur etiam verbis non discrepare ? at quot sunt ex hoc
-                      genere, et apud nos, et apud Italos, et Gallos ? Ejusdem factionis sunt, qui
-                      Arcadias, et Dianas, et id genus vanissimos libros conscribunt, quos
-                      adolescentuli tenera ætate imbibant, et virgines atque honestæ fœminæ in sinu
-                      gestent, ut fiant inhonestæ. Quid dicam de vanis, ac perditis hominibus
-                      errantibus, et in errorem mittentibus, qui fictorum Heroum quasi res gestas
-                      litteris mandant, et ardentes amores eorum, amatoria colloquia, et facta
-                      turpissima configunt, quibus in animis juvenum atque etiam virorum ignem
-                      incendunt gehennæ ? Hujus generis libros quamplurimos aut soli Hispani
-                      habemus, aut plures quam alii, neque prohibentur unquam ; sed impune a quavis
-                      ætate, a quavis conditione legentur, in magnam honestorum morum depravationem…
-                      Quot putabimus ab istis Emissarios dari Regi Assyriorum, id est, diabolo, ut
-                      expugnent pudicitiam, et Christianæ vitæ puritatem.</quote></p><p><quote>« Sed
-                      levia sunt hæc, olim enim legenda flagitia præbebantur ; nunc spectanda
-                      præbentur ; novit enim versutissimus artifex malorum segnius irritate animum
-                      demissa per aures, quam quæ sunt oculis subjecta fidelibus, et quæ ipse sibi
-                      tradit spectator. Idcirco quæ turpiter legebantur, novis Comœdiis agendis
-                      multo turpius spectari voluit in Theatro. Deploravit hoc olim Cyprianus his
-                      verbis : <quote>« Admonetur atas omnis auditu, fieri posse quod factum est :
-                        numquam avi senio delicta moriuntur, numquam temporibus crimen obruitur,
-                        numquam scelus oblivione sepelitur : exempla fiunt, qua esse jam facinora
-                        destiterunt. Tum delectat in Mimis turpitudinum magisterio vel quid domi
-                        gesserit, recognoscere vel quid gerere possit, audire : adulterium discitur,
-                        dum videtur : et lenocinante ad vitia publica authoritatis malo, quæ pudica
-                        fortasse ad spectaculum matrona processerat, de spectaculo revertitur
-                        impudica. Adhuc deinde morum quanta labes, quæ probrorum formenta, quæ
-                        alimenta vitiorum, histrionicis gestibus inquinari ? Videre contra fœdus,
-                        jusque nascendi patientiam incesta turpitudinis elaboratam ? Evirantur
-                        mares, honor omnis, et vigor sexus enervati corporis dedecore mollitur,
-                        plusque illic placet quisquis virum in fœminam magis fregerit : in laudem
-                        crescit ex crimine, et peritior, quo turpior judicatur. Spectatur hic, proh
-                        nefas, et libenter. Quid non possit suadere qui talis est ? Movet sensus,
-                        mulcet affectus, expugnat boni pectoris conscientiam fortiorem, nec deest
-                        probri blandientes autoritas, ut auditu molliore pernicies hominibus
+              paroles du Prophète : </p>
+            <quote><p>« Il donnera des Emissaires contre l’héritage de Geth</p><p>Ceux qui donnent
+                des Emissaires au Roi des Assyriens<note place="margin" resp="author"><quote><p>« At
+                      non illi Emissarios dant Regi Assyriorum, id est, diabolo, qui prodigi ingenii
+                      sui, atque otii ac nequitiæ suæ Poëtæ peccatum suum velut Sodoma, prædicantes,
+                      amatoria, et lasciva carmina scribunt, perinde ac si Ethnici essent, a quibus
+                      cum sensu, et voluntate non admodum discreperit, lætantur etiam verbis non
+                      discrepare ? at quot sunt ex hoc genere, et apud nos, et apud Italos, et
+                      Gallos ? Ejusdem factionis sunt, qui Arcadias, et Dianas, et id genus
+                      vanissimos libros conscribunt, quos adolescentuli tenera ætate imbibant, et
+                      virgines atque honestæ fœminæ in sinu gestent, ut fiant inhonestæ. Quid dicam
+                      de vanis, ac perditis hominibus errantibus, et in errorem mittentibus, qui
+                      fictorum Heroum quasi res gestas litteris mandant, et ardentes amores eorum,
+                      amatoria colloquia, et facta turpissima configunt, quibus in animis juvenum
+                      atque etiam virorum ignem incendunt gehennæ ? Hujus generis libros
+                      quamplurimos aut soli Hispani habemus, aut plures quam alii, neque prohibentur
+                      unquam ; sed impune a quavis ætate, a quavis conditione legentur, in magnam
+                      honestorum morum depravationem… Quot putabimus ab istis Emissarios dari Regi
+                      Assyriorum, id est, diabolo, ut expugnent pudicitiam, et Christianæ vitæ
+                      puritatem.</p><p>Sed levia sunt hæc, olim enim legenda flagitia præbebantur ;
+                      nunc spectanda præbentur ; novit enim versutissimus artifex malorum segnius
+                      irritate animum demissa per aures, quam quæ sunt oculis subjecta fidelibus, et
+                      quæ ipse sibi tradit spectator. Idcirco quæ turpiter legebantur, novis
+                      Comœdiis agendis multo turpius spectari voluit in Theatro. Deploravit hoc olim
+                      Cyprianus his verbis : <quote>« Admonetur atas omnis auditu, fieri posse quod
+                        factum est : numquam avi senio delicta moriuntur, numquam temporibus crimen
+                        obruitur, numquam scelus oblivione sepelitur : exempla fiunt, qua esse jam
+                        facinora destiterunt. Tum delectat in Mimis turpitudinum magisterio vel quid
+                        domi gesserit, recognoscere vel quid gerere possit, audire : adulterium
+                        discitur, dum videtur : et lenocinante ad vitia publica authoritatis malo,
+                        quæ pudica fortasse ad spectaculum matrona processerat, de spectaculo
+                        revertitur impudica. Adhuc deinde morum quanta labes, quæ probrorum
+                        formenta, quæ alimenta vitiorum, histrionicis gestibus inquinari ? Videre
+                        contra fœdus, jusque nascendi patientiam incesta turpitudinis elaboratam ?
+                        Evirantur mares, honor omnis, et vigor sexus enervati corporis dedecore
+                        mollitur, plusque illic placet quisquis virum in fœminam magis fregerit : in
+                        laudem crescit ex crimine, et peritior, quo turpior judicatur. Spectatur
+                        hic, proh nefas, et libenter. Quid non possit suadere qui talis est ? Movet
+                        sensus, mulcet affectus, expugnat boni pectoris conscientiam fortiorem, nec
+                        deest probri blandientes autoritas, ut auditu molliore pernicies hominibus
                         obrepat. »</quote> Hæc et plura Cyprianus in epistola ad Donatum ; sed de
                       suorum temporum malis. Quid feceret si nunc in Christianorum theatris sederet,
                       si Comœdias quæ aguntur spectaret ? Non jam enervantur mares ; sed fœminæ ipsæ
@@ -17626,113 +17373,104 @@
                       fœminis debuerant, et quæ honeste dici non possunt, inhoneste cogitantur ;
                       saltant, corpora lascive inflectunt ; dumque ea, et pejora fortasse, avari
                       mariti, patresque patiuntur, non majoribus Æthna incendiis æstuat, quam eorum
-                      pectora qui spectant et audiunt.</quote></p><p><quote>« Nec hæc impudicis
-                      tantum oculis con emplanda proponuntur ; sed sacris etiam interdum, ac Deo
-                      dicatis. Adde quod eo maxime tempore hæc agi videntur, quo multo
-                      Concionatorum, et cæterorum Dei Ministrorum sudore diabolus ex hominibus
-                      fuerat fugatus ; id est continuo post Dominici natalis, et sancti Paschæ
-                      Ferias, ut videlicet assumat septem alios spiritus nequiores se, et inveniat
-                      veteres domos scopis mundatas, et fiant novissima relapsorum pejora prioribus.
-                        <quote>« Audite ergo, Reges, et intelligite, discite Judices finuim terræ :
-                        Præbete aures vos qui continetis multitudines, et placetis vobis in turbis
-                        nationum, quoniam data est a Domino potestas vobis, et virtus ab Altissimo,
-                        qui interrrogabit opera vestra, et cogitationes scrutabitur. »</quote> Sap.
-                      6. Et quoniam Ministri estis illius, ut ait Spiritus sanctus, cohibete hos
-                      Emissarios ministriorum diaboli, quos jam commemoravi : idque vos obtestor qui
-                      potestis. <quote>« Per adventum Domini nostri Jesu Christi, qui judicaturus
-                        est vivos et mortuos, qui dedit semetipsum pro nobis, ut nos redimeret ab
-                        omni iniquitate, et mundaret sibi populum acceptabilem, spectatorem bonorum
-                        operum. »</quote> Tit. 2.</quote></p><p><quote>« Omnes etiam qui hæc legent
-                      si quis tamen legere volet, per eumdem Dominum obtestor, ut vel in
-                      concionibus, vel in sacris confessionibus, vel in privatis colloquiis,
-                      quocumque tempore se dabit occasio, Reges admoneant, ac Principes, ac Regios
-                      Senatores, Præteresque civitatum ; nec tantum admoneant ; sed etiam per Jesum
-                      Christum obtestentur, ut in istos morum Christianorum corruptores severe
-                      animadvertant, libros illos de medio tollant, infames hujusmodi Comœdiarum
-                      Authores, et Actores, Actricesque procul relegent, et hanc tetram Reipublicæ
-                      sentinam quocumque exonerent. »</quote> Ribear in cap. 1. Michea v. 14. Dabit
-                    Emissarios super hæreditatem Geth.</p></note>, c’est-à-dire au Diable, ne
-                sont-ce pas ces Poètes qui faisant un mauvais usage de leur esprit et de leur
-                loisir, <pb n="392" xml:id="p392"/> et faisant gloire, comme Sodome, de publier
-                leurs crimes, et leurs ordures, composent des vers d’amour, et d’impureté, comme
-                s’ils étaient des Païens ? Aussi leur étant assez semblables dans leurs sentiments,
-                et dans leurs passions, ils se plaisent encore à les imiter dans leurs paroles.
-                Combien y a-t-il de ces Poètes dans l’Espagne, dans l’Italie, et dans la France ?
-                Les faiseurs de Romans sont une même espèce de gens ; qui ne composent que des
-                livres vains, et profanes, dont la lecture ne peut servir qu’à corrompre les bonnes
-                mœurs des Enfants, des jeunes hommes, des jeunes filles, et même des honnêtes femmes
-                qui les ont d’ordinaire entre les mains. Que dirai-je de ces imposteurs qui y
-                séduisent les autres, étant séduits eux-mêmes, qui dans les contes qu’ils écrivent
-                des Héros fabuleux, décrivent les transports de leurs amours, leurs entretiens
-                lascifs, et leurs actions honteuses ; et par ces fictions criminelles allument un
-                feu infernal dans les âmes des jeunes hommes, et de ceux même qui sont d’un âge plus
-                avancé ? Nous avons une infinité de ces livres en Espagne, et il n’y a presque que
-                nous qui en ayons, ou du moins nous en avons plus que toutes les autres nations. Et
-                cependant ils ne sont point défendus ; et toutes sortes de personnes de quelque âge,
-                et de quelque condition qu’ils soient les lisent impunément, par une étrange
-                corruption des bonnes mœurs. Combien d’Emissaires croirons-nous que ces gens-là
-                donnent au Roi d’Assyrie, c’est-à-dire, au diable, pour détruire l’honnêteté, et la
-                pureté de la vie chrétienne ?</quote>
-            </p>
-            <p>
-              <quote>« Mais ces dérèglements paraîtront légers, si nous les comparons avec ceux dont
-                je vais parler. On nous apprenait autrefois les crimes par la lecture des livres ;
-                mais aujourd’hui on nous les apprend en nous les faisant voir. Ce fin ouvrier
-                d’iniquité sachant bien que ce qui n’entre dans l’esprit que par les oreilles touche
-                moins les hommes, que ce qu’ils voient, et regardent de leurs propres yeux, a
-                introduit de nouveau des Comédies, afin que ce qui n’était connu que par une lecture
-                honteuse, fût exposé sur le Théâtre aux yeux de tout le monde, par des
-                représentations beaucoup plus honteuses. C’est ce que saint Cyprien déplorait dans
-                son <pb n="393" xml:id="p393"/> temps, en ces termes : <quote>« Les hommes de
-                  quelque âge, et de quelque sexe qu’ils soient, apprennent qu’un crime se peut
-                  faire, en apprenant qu’il s’est fait. Les péchés ne meurent point par la
-                  vieillesse du temps, les années ne couvrent point les crimes, et on ne perd jamais
-                  le souvenir des mauvaises actions : elles ont cessé d’être des crimes ; et elles
-                  deviennent des exemples. On prend plaisir à voir représenter dans la Comédie ce
-                  qu’on a fait en sa maison, ou à entendre ce qu’on y peut faire : on apprend
-                  l’adultère en le voyant représenter ; et le mal qui est autorisé publiquement, a
-                  tant de charmes, qu’il arrive que des femmes qui étaient peut-être chastes
-                  lorsqu’elles sont allées aux Spectacles, en sortent impudiques. Les Farceurs avec
-                  leurs actions déshonnêtes ne corrompent-ils pas les mœurs ? Ne portent-ils pas à
-                  la débauche ? N’entretiennent-ils pas les vices ? On y voit violer l’alliance, et
-                  le droit de la naissance par des infâmes incestes qu’on y représente. On fait
-                  changer de sexe aux garçons, on les accoutume à des gestes honteux, et à des
-                  postures efféminées, qui énervent<note place="bottom" resp="editor"> [NDE] Ôter la
-                    force physique ou morale (Littré).</note>, et abattent toute la majesté et la
-                  vigueur de leur sexe : et un homme ne plaît qu’à proportion qu’il fait paraître la
-                  délicatesse, et la mollesse d’une fille.  </quote></quote>
-            </p>
-            <p> « <quote>« Il tire sa louange de son crime ; et plus il est impudique, plus il est
-                estimé habile : Voilà celui que tout le monde regarde ; et ce qui est honteux, qu’on
-                regarde avec plaisir. Y a-t-il de crime qu’un homme tel que celui-là ne puisse
-                persuader ? Il émeut les sens, il flatte les passions, il abat l’âme la plus
-                vigoureuse, et la plus forte vertu. Ces corrupteurs agréables ne manquent pas
-                d’exemples de personnes illustres, dont les crimes les autorisent, et leur servent à
-                insinuer plus doucement leur poison dans les cœurs de ceux qui les
-                écoutent. »</quote>
-            </p>
-            <p>
-              <quote>« Voilà une partie de ce que dit saint Cyprien, dans l’Epitre qu’il écrit à
-                Donat sur le sujet des dérèglements de son temps. Que dirait-il s’il voyait
-                aujourd’hui les Théâtres <pb n="394" xml:id="p394"/> des Chrétiens, et les Comédies
-                qui y sont jouées ? On ne fait point aujourd’hui changer de sexe aux garçons ; mais
-                des femmes deviennent hommes. Un homme ne se déguise plus en femme ; mais une femme
-                se déguise en homme. L’ennemi du genre humain ne s’est pas contenté de représenter
-                des ordures feintes ; il en représente de véritables. Des femmes montent maintenant
-                sur le Théâtre ; et font les personnages de femmes que les hommes avaient
-                anciennement accoutumé de faire. Ce qui n’émouvait pas tant les spectateurs. Une
-                belle Comédienne, mais d’une vie infâme paraît bien parée devant des spectateurs
-                pour augmenter leurs flammes. Elle fait encore elle-même le personnage d’un homme,
-                ou d’un jeune amoureux, pleurant, et se perdant par des transports d’amour, et
+                      pectora qui spectant et audiunt.</p><p>Nec hæc impudicis tantum oculis con
+                      emplanda proponuntur ; sed sacris etiam interdum, ac Deo dicatis. Adde quod eo
+                      maxime tempore hæc agi videntur, quo multo Concionatorum, et cæterorum Dei
+                      Ministrorum sudore diabolus ex hominibus fuerat fugatus ; id est continuo post
+                      Dominici natalis, et sancti Paschæ Ferias, ut videlicet assumat septem alios
+                      spiritus nequiores se, et inveniat veteres domos scopis mundatas, et fiant
+                      novissima relapsorum pejora prioribus. <quote>« Audite ergo, Reges, et
+                        intelligite, discite Judices finuim terræ : Præbete aures vos qui continetis
+                        multitudines, et placetis vobis in turbis nationum, quoniam data est a
+                        Domino potestas vobis, et virtus ab Altissimo, qui interrrogabit opera
+                        vestra, et cogitationes scrutabitur. »</quote> Sap. 6. Et quoniam Ministri
+                      estis illius, ut ait Spiritus sanctus, cohibete hos Emissarios ministriorum
+                      diaboli, quos jam commemoravi : idque vos obtestor qui potestis. <quote>« Per
+                        adventum Domini nostri Jesu Christi, qui judicaturus est vivos et mortuos,
+                        qui dedit semetipsum pro nobis, ut nos redimeret ab omni iniquitate, et
+                        mundaret sibi populum acceptabilem, spectatorem bonorum operum. »</quote>
+                      Tit. 2.</p><p>Omnes etiam qui hæc legent si quis tamen legere volet, per
+                      eumdem Dominum obtestor, ut vel in concionibus, vel in sacris confessionibus,
+                      vel in privatis colloquiis, quocumque tempore se dabit occasio, Reges
+                      admoneant, ac Principes, ac Regios Senatores, Præteresque civitatum ; nec
+                      tantum admoneant ; sed etiam per Jesum Christum obtestentur, ut in istos morum
+                      Christianorum corruptores severe animadvertant, libros illos de medio tollant,
+                      infames hujusmodi Comœdiarum Authores, et Actores, Actricesque procul
+                      relegent, et hanc tetram Reipublicæ sentinam quocumque
+                    exonerent. »</p></quote><p>Ribear in cap. 1. Michea v. 14. Dabit Emissarios
+                    super hæreditatem Geth.</p></note>, c’est-à-dire au Diable, ne sont-ce pas ces
+                Poètes qui faisant un mauvais usage de leur esprit et de leur loisir, <pb n="392"
+                  xml:id="p392"/> et faisant gloire, comme Sodome, de publier leurs crimes, et leurs
+                ordures, composent des vers d’amour, et d’impureté, comme s’ils étaient des Païens ?
+                Aussi leur étant assez semblables dans leurs sentiments, et dans leurs passions, ils
+                se plaisent encore à les imiter dans leurs paroles. Combien y a-t-il de ces Poètes
+                dans l’Espagne, dans l’Italie, et dans la France ? Les faiseurs de Romans sont une
+                même espèce de gens ; qui ne composent que des livres vains, et profanes, dont la
+                lecture ne peut servir qu’à corrompre les bonnes mœurs des Enfants, des jeunes
+                hommes, des jeunes filles, et même des honnêtes femmes qui les ont d’ordinaire entre
+                les mains. Que dirai-je de ces imposteurs qui y séduisent les autres, étant séduits
+                eux-mêmes, qui dans les contes qu’ils écrivent des Héros fabuleux, décrivent les
+                transports de leurs amours, leurs entretiens lascifs, et leurs actions honteuses ;
+                et par ces fictions criminelles allument un feu infernal dans les âmes des jeunes
+                hommes, et de ceux même qui sont d’un âge plus avancé ? Nous avons une infinité de
+                ces livres en Espagne, et il n’y a presque que nous qui en ayons, ou du moins nous
+                en avons plus que toutes les autres nations. Et cependant ils ne sont point
+                défendus ; et toutes sortes de personnes de quelque âge, et de quelque condition
+                qu’ils soient les lisent impunément, par une étrange corruption des bonnes mœurs.
+                Combien d’Emissaires croirons-nous que ces gens-là donnent au Roi d’Assyrie,
+                c’est-à-dire, au diable, pour détruire l’honnêteté, et la pureté de la vie
+                chrétienne ?</p><p>Mais ces dérèglements paraîtront légers, si nous les comparons
+                avec ceux dont je vais parler. On nous apprenait autrefois les crimes par la lecture
+                des livres ; mais aujourd’hui on nous les apprend en nous les faisant voir. Ce fin
+                ouvrier d’iniquité sachant bien que ce qui n’entre dans l’esprit que par les
+                oreilles touche moins les hommes, que ce qu’ils voient, et regardent de leurs
+                propres yeux, a introduit de nouveau des Comédies, afin que ce qui n’était connu que
+                par une lecture honteuse, fût exposé sur le Théâtre aux yeux de tout le monde, par
+                des représentations beaucoup plus honteuses. C’est ce que saint Cyprien déplorait
+                dans son <pb n="393" xml:id="p393"/> temps, en ces termes :</p>
+              <quote><p>« Les hommes de quelque âge, et de quelque sexe qu’ils soient, apprennent
+                  qu’un crime se peut faire, en apprenant qu’il s’est fait. Les péchés ne meurent
+                  point par la vieillesse du temps, les années ne couvrent point les crimes, et on
+                  ne perd jamais le souvenir des mauvaises actions : elles ont cessé d’être des
+                  crimes ; et elles deviennent des exemples. On prend plaisir à voir représenter
+                  dans la Comédie ce qu’on a fait en sa maison, ou à entendre ce qu’on y peut
+                  faire : on apprend l’adultère en le voyant représenter ; et le mal qui est
+                  autorisé publiquement, a tant de charmes, qu’il arrive que des femmes qui étaient
+                  peut-être chastes lorsqu’elles sont allées aux Spectacles, en sortent impudiques.
+                  Les Farceurs avec leurs actions déshonnêtes ne corrompent-ils pas les mœurs ? Ne
+                  portent-ils pas à la débauche ? N’entretiennent-ils pas les vices ? On y voit
+                  violer l’alliance, et le droit de la naissance par des infâmes incestes qu’on y
+                  représente. On fait changer de sexe aux garçons, on les accoutume à des gestes
+                  honteux, et à des postures efféminées, qui énervent<note place="bottom"
+                    resp="editor"> [NDE] Ôter la force physique ou morale (Littré).</note>, et
+                  abattent toute la majesté et la vigueur de leur sexe : et un homme ne plaît qu’à
+                  proportion qu’il fait paraître la délicatesse, et la mollesse d’une
+                  fille.</p><p>Il tire sa louange de son crime ; et plus il est impudique, plus il
+                  est estimé habile : Voilà celui que tout le monde regarde ; et ce qui est honteux,
+                  qu’on regarde avec plaisir. Y a-t-il de crime qu’un homme tel que celui-là ne
+                  puisse persuader ? Il émeut les sens, il flatte les passions, il abat l’âme la
+                  plus vigoureuse, et la plus forte vertu. Ces corrupteurs agréables ne manquent pas
+                  d’exemples de personnes illustres, dont les crimes les autorisent, et leur servent
+                  à insinuer plus doucement leur poison dans les cœurs de ceux qui les
+                  écoutent. »</p></quote>
+              <p>Voilà une partie de ce que dit saint Cyprien, dans l’Epitre qu’il écrit à Donat sur
+                le sujet des dérèglements de son temps. Que dirait-il s’il voyait aujourd’hui les
+                Théâtres <pb n="394" xml:id="p394"/> des Chrétiens, et les Comédies qui y sont
+                jouées ? On ne fait point aujourd’hui changer de sexe aux garçons ; mais des femmes
+                deviennent hommes. Un homme ne se déguise plus en femme ; mais une femme se déguise
+                en homme. L’ennemi du genre humain ne s’est pas contenté de représenter des ordures
+                feintes ; il en représente de véritables. Des femmes montent maintenant sur le
+                Théâtre ; et font les personnages de femmes que les hommes avaient anciennement
+                accoutumé de faire. Ce qui n’émouvait pas tant les spectateurs. Une belle
+                Comédienne, mais d’une vie infâme paraît bien parée devant des spectateurs pour
+                augmenter leurs flammes. Elle fait encore elle-même le personnage d’un homme, ou
+                d’un jeune amoureux, pleurant, et se perdant par des transports d’amour, et
                 découvrant ce que les femmes doivent cacher, elles donnent lieu de penser à des
                 choses honteuses, que l’honnêteté ne permet pas de dire : elles dansent avec des
                 postures lascives ; et pendant que les pères, et les maris avares souffrent ces
                 choses ou d’autres, qui sont peut-être pires, les cœurs de ceux qui les voient, et
                 qui les écoutent, brûlent d’un feu, qui n’est pas moins violent, que celui du mont
-                Etna.</quote>
-            </p>
-            <p>
-              <quote>«  Et ce ne sont pas seulement des yeux impudiques qui regardent ces
+                Etna.</p><p>Et ce ne sont pas seulement des yeux impudiques qui regardent ces
                 spectacles, mais ce sont quelquefois des yeux même consacrés à Dieu. Ajoutez à cela
                 qu’on voit ces dérèglements dans le temps principalement que le diable est chassé
                 des cœurs des hommes, par les soins des Prédicateurs, et des autres Ministres de
@@ -17752,19 +17490,16 @@
                   morts dans son avènement glorieux ; qui s’est livré lui-même pour nous, afin de
                   nous racheter de toute iniquité, et de nous purifier pour se faire un peuple
                   particulièrement consacré à son service, et fervent dans les bonnes
-                  œuvres. »</quote> Tit. 2.</quote>
-            </p>
-            <p>
-              <quote>« Je conjure aussi par le même Seigneur Jésus-Christ, tous ceux qui liront ce
-                discours, s’ils veulent prendre la peine de le lire, d’avertir dans leurs sermons,
-                ou dans les sacrées confessions, ou dans les entretiens particuliers, et dans toutes
-                les occasions qui si présenteront, les Rois, les Princes, les Conseillers des Rois,
-                et les Chefs de la Justice des villes ; et je les prie non seulement de les avertir,
-                mais de les conjurer par Notre Seigneur Jésus-Christ de punir sévèrement ces
-                corrupteurs des mœurs des Chrétiens ; de supprimer les Romans, de bannir les infâmes
-                auteurs des Comédies, et les Comédiens, et les Comédiennes : et de vider cette sale
-                sentine de la République. »</quote>
-            </p>
+                  œuvres. »</quote> Tit. 2.</p><p>Je conjure aussi par le même Seigneur
+                Jésus-Christ, tous ceux qui liront ce discours, s’ils veulent prendre la peine de le
+                lire, d’avertir dans leurs sermons, ou dans les sacrées confessions, ou dans les
+                entretiens particuliers, et dans toutes les occasions qui si présenteront, les Rois,
+                les Princes, les Conseillers des Rois, et les Chefs de la Justice des villes ; et je
+                les prie non seulement de les avertir, mais de les conjurer par Notre Seigneur
+                Jésus-Christ de punir sévèrement ces corrupteurs des mœurs des Chrétiens ; de
+                supprimer les Romans, de bannir les infâmes auteurs des Comédies, et les Comédiens,
+                et les Comédiennes : et de vider cette sale sentine de la République. »</p></quote>
+
             <p>Le Père Ribera condamne dans ce discours toutes les propositions fondamentales de la
               Dissertation. Car lorsque après avoir rapporté ce que dit saint Cyprien contre les
               Comédies de son temps, il ajoute : <quote>« Que dirait saint Cyprien, s’il voyait
@@ -17794,17 +17529,17 @@
                 plus ord, et le plus déshonnête qu’on pût choisir, laissent une impression vive en
                 l’âme de ceux qui tendent là tous leurs sens. Bref on peut dire que le Théâtre des
                 Joueurs est un théâtre et un apprentissage de toute impudicité, lubricité,
-                paillardise, ruse, finesse, méchanceté. Et non sans cause, disait Aristote</quote>
-              <note place="margin" resp="author">7. <hi rend="i">Polit</hi>. cap. 15.</note>
-              <quote>, qu’il faut bien garder les sujets d’aller aux Jeux Comiques. Il eût
-                encore mieux dit, qu’il faut raser les Théâtres, et fermer les portes de la ville
-                aux joueurs, <quote>« Quia<seg type="exquote">, dit Sénèque,</seg> nihil tam moribus
-                  alienum, quam in spectaculis desidere. »</quote> Et pour cette cause Philippe
-                Auguste Roi de France, par Edit exprès, chassa hors du Royaume tous les Bateleurs.
-                Si on dit que les Grecs et Romains permettaient les jeux, je réponds que c’était
-                pour une superstition qu’ils avaient à leurs Dieux ; mais les plus sages les ont
-                toujours blâmés ; car combien que la Tragédie a je ne sais quoi de plus héroïque, et
-                qui moins effémine les cœurs des hommes ; si est-ce toutefois que Solon ayant vu une
+                paillardise, ruse, finesse, méchanceté. Et non sans cause, disait Aristote <note
+                  place="margin" resp="author">7. <hi rend="i">Polit</hi>. cap. 15.</note>, qu’il
+                faut bien garder les sujets d’aller aux Jeux Comiques. Il eût encore mieux dit,
+                qu’il faut raser les Théâtres, et fermer les portes de la ville aux joueurs,
+                    <quote>« Quia<seg type="exquote">, dit Sénèque,</seg> nihil tam moribus alienum,
+                  quam in spectaculis desidere. »</quote> Et pour cette cause Philippe Auguste Roi
+                de France, par Edit exprès, chassa hors du Royaume tous les Bateleurs. Si on dit que
+                les Grecs et Romains permettaient les jeux, je réponds que c’était pour une
+                superstition qu’ils avaient à leurs Dieux ; mais les plus sages les ont toujours
+                blâmés ; car combien que la Tragédie a je ne sais quoi de plus héroïque, et qui
+                moins effémine les cœurs des hommes ; si est-ce toutefois que Solon ayant vu une
                 Tragédie <pb n="397" xml:id="p397"/> de Thespis, le trouva fort mauvais : de quoi
                 s’excusant Thespis, disait que ce n’était que jeu. <quote>« Non, <seg type="exquote"
                     >dit Solon,</seg> mais le jeu tourne en chose sérieuse. »</quote> Beaucoup plus
@@ -17823,31 +17558,30 @@
             <head>PREUVES DU XVII. SIECLE CONTRE la Comédie.</head>
             <p>Le Concile de Bordeaux tenu l’an 1624. renouvelle les défenses faites aux
               Ecclésiastiques d’assister à la Comédie, par le Concile précédent tenu l’an 1583. Le
-              Père Comitolus montre par cinq preuves<note place="margin" resp="author"><p>
-                  <quote>« Quinque viis ostendimus, tum eos qui agunt, qui audiunt impudicas
-                    Comœdias, culpam lætalem non effugere.</quote></p><p><quote>« Prima est sacrarum
-                    sactionum et legum civilium Ecclesiastica psephismata in Actores turpium
-                    fabularum duo sunt satis expressa : alterum in Canone pro dilectione : alterum
-                    in Canone qui sequitur. In priore huic hominum generi Ecclesiastica Communio
-                    denegatur : quæ pœna criminosis tantum actionibus irrogatur. In posteriore
-                    personæ apostaticæ nominantur. Prior canon sumptus est ex epistola 10. S.
-                    Cypriani ad Euchratium l. 1. Alter e tertio Concilio Carthaginensi cap. 31.
-                    uterque vero Canon reperitur in 2. dist. De cons. Paul Comitol. Resp. Moral l.
-                    5. quæst. 11. de obscœnis Comœdiis. »</quote></p></note>, <quote>« que tant ceux
-                qui jouent des Comédies impudiques que ceux qui les écoutent, commettent un péché
-                mortel</quote>.</p>
-            <p>
-              <quote>« La première preuve est tirée des sacrés Canons, et des lois civiles. Quant à
-                ce qui regarde les sacrés Canons et les Décrets de l’Eglise, il y en a deux qui sont
-                assez exprès ; si l’un est le Canon <hi rend="i">pro dilectione</hi> , l’autre est
-                le Canon suivant <hi rend="i">Scenicis, atque Histrionibus</hi>  ; le premier prive
-                ces sortes de gens de la Communion Ecclésiastique, ce qui est une peine qui n’est
-                imposée que pour des crimes, et pour des péchés mortels. Dans l’autre Canon les
-                Acteurs sont appelés apostats : le premier canon est tiré de l’Epitre 10. de saint
-                Cyprien à Euchratius : l’autre est pris du chapitre 31. du 3. Concile de Carthage ;
-                et l’un l’autre sont insérés <pb n="398" xml:id="p398"/> dans le Droit Canonique,
-                  <hi rend="i">de consecrat. dist. 2.</hi>  »</quote>
-            </p>
+              Père Comitolus montre par cinq preuves<note place="margin" resp="author">
+                <quote><p>« Quinque viis ostendimus, tum eos qui agunt, qui audiunt impudicas
+                    Comœdias, culpam lætalem non effugere.</p><p>Prima est sacrarum sactionum et
+                    legum civilium Ecclesiastica psephismata in Actores turpium fabularum duo sunt
+                    satis expressa : alterum in Canone pro dilectione : alterum in Canone qui
+                    sequitur. In priore huic hominum generi Ecclesiastica Communio denegatur : quæ
+                    pœna criminosis tantum actionibus irrogatur. In posteriore personæ apostaticæ
+                    nominantur. Prior canon sumptus est ex epistola 10. S. Cypriani ad Euchratium l.
+                    1. Alter e tertio Concilio Carthaginensi cap. 31. uterque vero Canon reperitur
+                    in 2. dist. De cons. Paul Comitol. Resp. Moral l. 5. quæst. 11. de obscœnis
+                    Comœdiis. »</p></quote></note>, </p>
+            <quote><p>« que tant ceux qui jouent des Comédies impudiques que ceux qui les écoutent,
+                commettent un péché mortel</p><p>La première preuve est tirée des sacrés Canons, et
+                des lois civiles. Quant à ce qui regarde les sacrés Canons et les Décrets de
+                l’Eglise, il y en a deux qui sont assez exprès ; si l’un est le Canon <hi rend="i"
+                  >pro dilectione</hi> , l’autre est le Canon suivant <hi rend="i">Scenicis, atque
+                  Histrionibus</hi>  ; le premier prive ces sortes de gens de la Communion
+                Ecclésiastique, ce qui est une peine qui n’est imposée que pour des crimes, et pour
+                des péchés mortels. Dans l’autre Canon les Acteurs sont appelés apostats : le
+                premier canon est tiré de l’Epitre 10. de saint Cyprien à Euchratius : l’autre est
+                pris du chapitre 31. du 3. Concile de Carthage ; et l’un l’autre sont insérés <pb
+                  n="398" xml:id="p398"/> dans le Droit Canonique, <hi rend="i">de consecrat. dist.
+                  2.</hi>  »</p></quote>
+
             <p>D’où il s’ensuit que selon Comitolus les Poèmes Dramatiques ont été condamnés, et que
               par conséquent la proposition de l’Auteur de la Dissertation pag. 229. n’est pas
               véritable selon Comitolus.</p>
@@ -17945,8 +17679,7 @@
             <p>
               <quote>« Voyez encore Durand <seg type="exquote">, ajoute Comitolus <note
                     place="margin" resp="author">
-                    <p>
-                      <quote>« Vide Durandum, in 4. dist. 179. S. Antoninum in 2. p. Tit. 3 cap. 7.
+                    <quote><p>« Vide Durandum, in 4. dist. 179. S. Antoninum in 2. p. Tit. 3 cap. 7.
                         §. 5. si repræsentant, inquit, multum turpia, et lasciva, ea exercentes
                         mortaliter peccant ; et inspectio voluntaria talium, mortale est ; quia
                         nihil est aliud, quam delectari de turpibus ; tum quia periculo tentationis
@@ -17954,126 +17687,77 @@
                         asciomate utitur : quisquis delectatur in peccato mortali, peccat
                         mortaliter : in ipsos istos Actores, et Spectatores impudicarum Comœdiarum,
                         tanquam in mortiferi peccati reos sententiam dicit Cajetamus in 2. 2. q.
-                        167. art. 2. ad 2. et in summa V. spectacula, et c. </quote></p>
-                    <p>
-                      <quote>« Cumulatur vero idem istud scelus cum diebus festis committitur contra
-                        legem postremam Codicis de Ferijs, his verbis jubentem : <quote>« Dies
-                          Majestati altissimæ dedicatos nullis volumus voluptatibus occupari ; et de
-                          Dominica die præcipiens ait : Nec tamen hujus religiosæ diei otio
-                          relachantes obscœnis quemquam patimur voluptatibus detineri, nihil de
-                          eodem die sibi vindicet Scena theatralis, aut Circense certamen, aut
-                          ferarum lacrymosa spectacula : et si in nostrum ortum, aut natalem
-                          celebranda solennitas inciderit differatur. et c. »</quote></quote>
-                    </p>
-                    <p>
-                      <quote>« Et quoniam lex hujusmodi justa est divinum sanciens cultum, remque
-                        permagni interest, jubens, ab eo qui orbi terræ legitime imperabat
-                        constituta, et a cunctis provinciis recepta, sine crimine contemni non
-                        potest. De qua lege cum mentionem fecisset Richardus in 4. dist. 37. art. 2.
-                        quæst. 4. ad 3. argum. culpam mortiferam esse concludit ex Magistrorum
-                        sententia ducere choræas, et hastiludia facere diebus Dominicis.</quote>
-                    </p>
-                    <p>
-                      <quote>« Quarta est via argumentorum e principiis moralis Philosophiæ et
-                        Theologiæ erutorum.</quote>
-                    </p>
-                    <p>
-                      <quote>« Et primum quidem probandum est crimen sibi facere, qui cum
-                        turpitudine et obscœnitate agunt Comœdias ; deinde eos qui ad eos audiendos
-                        adeunt. Contra primos hæ sunt argumentationes.</quote>
-                    </p>
-                    <p>
-                      <quote>« 1. Seipsum, et alios ea virtute privare, sine qua nulli datur æterna
-                        a Deo salus, scelus est ingens ; charitatem enim id extinguit : sed cordis
-                        munditia, sine qua nemo videbit Deum, sponte se et alios privat, qui palam
-                        in obscœnarum rerum imitatione versatur. Quare, et c. </quote>
-                    </p>
-                    <p>
-                      <quote>« 2. Nimium scelerate agit qui fundamenta civitatum, et rerum
+                        167. art. 2. ad 2. et in summa V. spectacula, et c.</p><p>Cumulatur vero
+                        idem istud scelus cum diebus festis committitur contra legem postremam
+                        Codicis de Ferijs, his verbis jubentem : <quote>« Dies Majestati altissimæ
+                          dedicatos nullis volumus voluptatibus occupari ; et de Dominica die
+                          præcipiens ait : Nec tamen hujus religiosæ diei otio relachantes obscœnis
+                          quemquam patimur voluptatibus detineri, nihil de eodem die sibi vindicet
+                          Scena theatralis, aut Circense certamen, aut ferarum lacrymosa
+                          spectacula : et si in nostrum ortum, aut natalem celebranda solennitas
+                          inciderit differatur. et c. »</quote></p><p>Et quoniam lex hujusmodi justa
+                        est divinum sanciens cultum, remque permagni interest, jubens, ab eo qui
+                        orbi terræ legitime imperabat constituta, et a cunctis provinciis recepta,
+                        sine crimine contemni non potest. De qua lege cum mentionem fecisset
+                        Richardus in 4. dist. 37. art. 2. quæst. 4. ad 3. argum. culpam mortiferam
+                        esse concludit ex Magistrorum sententia ducere choræas, et hastiludia facere
+                        diebus Dominicis.</p><p>Quarta est via argumentorum e principiis moralis
+                        Philosophiæ et Theologiæ erutorum.</p><p>Et primum quidem probandum est
+                        crimen sibi facere, qui cum turpitudine et obscœnitate agunt Comœdias ;
+                        deinde eos qui ad eos audiendos adeunt. Contra primos hæ sunt
+                        argumentationes.</p><p>1. Seipsum, et alios ea virtute privare, sine qua
+                        nulli datur æterna a Deo salus, scelus est ingens ; charitatem enim id
+                        extinguit : sed cordis munditia, sine qua nemo videbit Deum, sponte se et
+                        alios privat, qui palam in obscœnarum rerum imitatione versatur. Quare, et
+                        c.</p><p>2. Nimium scelerate agit qui fundamenta civitatum, et rerum
                         publicarum, quæ sapienter institutæ sunt, evertit. Id isti nebulones
                         moliuntur, cum pudorem, modestiam, temperantiam, pudicitiam e civitatibus
-                        exterminant. Ergo, et c. </quote>
-                    </p>
-                    <p>
-                      <quote>« 3. Quicumque impedimento pueris sunt, quominus ad honestatem
-                        splendoremque civilem instituantur, gravissime peccant.</quote>
-                    </p>
-                    <p>
-                      <quote>« Id agunt impurarum Comœdiarum impurissimi actores. Igitur, et c.
-                      </quote>
-                    </p>
-                    <p>  «<quote>4. Qui Civitatum, et Rerumpublicarum finem verum corrompit, eum
+                        exterminant. Ergo, et c.</p><p>3. Quicumque impedimento pueris sunt,
+                        quominus ad honestatem splendoremque civilem instituantur, gravissime
+                        peccant.</p><p>Id agunt impurarum Comœdiarum impurissimi actores. Igitur, et
+                        c. </p><p>4. Qui Civitatum, et Rerumpublicarum finem verum corrompit, eum
                         corruptissimum moribus, et mente contaminatissimum esse necesse est ; sed
                         improbi Mimi, et Histriones id moliuntur, cum pro virtute quæ sola est ad
                         fœlicitatem via, vitium, et libidinem in civitatem infundunt : Omnium enim
                         justarum legum, et prudentum Legislatorum finis est, idemque
                         Rerumpublicarum, ut cives virtute præditi evadant, et virtute fœlicitatem
-                        adipiscantur.</quote>
-                    </p>
-                    <p>
-                      <quote>« 5. Qui in agendo aliquid criminosum intuetur, criminose agit. Sed qui
-                        fabulis, obscœnisque imitationibus auditorum aures, et oculos oblectant,
-                        ejusmodi voluptatem aut in tota fabula, aut in aliqua ejus parte propositam
-                        habent : agunt igitur criminose : estque eorum crimen aut scandali activi,
-                        ut loquuntur Theologi, aut homicidii spiritualis.</quote>
-                    </p>
-                    <p>
-                      <quote>« 6. Nemo ab Ecclesia Christiana Sacramento Communione privatur, nisi
-                        ob scelus æterna damnatione dignum.</quote>
-                    </p>
-                    <p>
-                      <quote>« At hi Mimi, et Histriones ejusmodi privantur Communione ; Quare, et
-                        c.</quote>
-                    </p>
-                    <p>
-                      <quote>« 7. Qui Poëma, Carmenve amatorium componeret, quo lectorum mentes ad
-                        libidinis illecebras, turpiumque rerum amorem inflammatum iri minime
-                        vereretur, scelus ederet, quo insigniter divina amicitia læderetur. Quanto
-                        igitur gravius eam violabit qui spectantium animos vitiorum tædis incendit,
-                        et exurit, non ad eorum oculos inanimato libello admoto, se ore, gestu,
-                        vultu, voce spirante libidinem, impudicitiam, atque lasciviam
-                        vibrante ?</quote>
-                    </p>
-                    <p>
-                      <quote>« 8. Impudicarum fabularum Actores, et Deum, illiusque augustas leges
-                        insigniter contemnunt, et spectatoribus vehementer nocent, et labem
-                        sibiipsis ingentem inferunt. Ergo peccant suarum animarum interitum
-                        conficiens.</quote>
-                    </p>
-                    <p>
-                      <quote>« Postremo tot sacrorum nobilissimi Antistites, tot publicæ religionis
-                        doctissimi interpretes : tot Theologicæ disciplinæ laude præstantes turpium
-                        Comœdiarum, et eas exercentium genus tanquam perflagitiosum, Deoque
-                        perinvisum condemnarunt. Igitur de qualitate et sceleris magnitudine
-                        dubitandum non est.</quote>
-                    </p>
-                    <p>
-                      <quote>« Proximum est ut in spectatores argumentorum aculeos convertamus. Sit
-                        igit prima ratio : exitialis flagitii alteri causam afferre, exitiale est.
-                        Sed spectatores suo accessu, et præsentia causam afferunt scenicis illa
-                        turpia imitandi, et agendi. Igitur, et c.</quote>
-                    </p>
-                    <p>
-                      <quote>« 2. Histrionibus ex eo genere pecunias largiri immane vitium est ex
-                        sancto Augustino, et ut scribit sanctus Hieronymus : Qui dat Histrionibus
-                        immolat dæmoniis. Ergo cum id faciant qui ad scenam properant, in vitio sunt
-                        immani, quasi diabolo immolantes.</quote>
-                    </p>
-                    <p>
-                      <quote>« 3. E culpa letali voluptatem capere, seu ex ea re quæ non est sine
-                        culpa letali, letale est crimen. Sed qui intersunt, Comœdiis obscœnis,
-                        voluptatem hauriunt ex actione Histrionum, quæ illis criminosa est. Ergo
-                        codem spectatores crimine inficiuntur.</quote>
-                    </p>
-                    <p>
-                      <quote>« 4. Chrisitanæ Ecclesiæ doctores, sacræ Theologiæ Magistri, de
-                        spectatorum peccato, ut nos, sentiunt. Ergo nos secus credere, aut opinari
-                        fas non est.</quote>
-                    </p>
-                    <p> «  <quote>Quinta via illorum Philosophorum est, qui Christianæ sapientiæ
-                        luce orbati fuerunt. Plato lib. 3. de Republica, in civitatem non vult
-                        recipi malarum turpiumve rerum Comœdiam, neque Comœdios ac</quote>
-                      <quote>Histriones. »</quote> Comitolus ibid. </p>
+                        adipiscantur.</p><p>5. Qui in agendo aliquid criminosum intuetur, criminose
+                        agit. Sed qui fabulis, obscœnisque imitationibus auditorum aures, et oculos
+                        oblectant, ejusmodi voluptatem aut in tota fabula, aut in aliqua ejus parte
+                        propositam habent : agunt igitur criminose : estque eorum crimen aut
+                        scandali activi, ut loquuntur Theologi, aut homicidii spiritualis.</p><p>6.
+                        Nemo ab Ecclesia Christiana Sacramento Communione privatur, nisi ob scelus
+                        æterna damnatione dignum.</p><p>At hi Mimi, et Histriones ejusmodi privantur
+                        Communione ; Quare, et c.</p><p>7. Qui Poëma, Carmenve amatorium componeret,
+                        quo lectorum mentes ad libidinis illecebras, turpiumque rerum amorem
+                        inflammatum iri minime vereretur, scelus ederet, quo insigniter divina
+                        amicitia læderetur. Quanto igitur gravius eam violabit qui spectantium
+                        animos vitiorum tædis incendit, et exurit, non ad eorum oculos inanimato
+                        libello admoto, se ore, gestu, vultu, voce spirante libidinem, impudicitiam,
+                        atque lasciviam vibrante ?</p><p>8. Impudicarum fabularum Actores, et Deum,
+                        illiusque augustas leges insigniter contemnunt, et spectatoribus vehementer
+                        nocent, et labem sibiipsis ingentem inferunt. Ergo peccant suarum animarum
+                        interitum conficiens.</p><p>Postremo tot sacrorum nobilissimi Antistites,
+                        tot publicæ religionis doctissimi interpretes : tot Theologicæ disciplinæ
+                        laude præstantes turpium Comœdiarum, et eas exercentium genus tanquam
+                        perflagitiosum, Deoque perinvisum condemnarunt. Igitur de qualitate et
+                        sceleris magnitudine dubitandum non est.</p><p>Proximum est ut in
+                        spectatores argumentorum aculeos convertamus. Sit igit prima ratio :
+                        exitialis flagitii alteri causam afferre, exitiale est. Sed spectatores suo
+                        accessu, et præsentia causam afferunt scenicis illa turpia imitandi, et
+                        agendi. Igitur, et c.</p><p>2. Histrionibus ex eo genere pecunias largiri
+                        immane vitium est ex sancto Augustino, et ut scribit sanctus Hieronymus :
+                        Qui dat Histrionibus immolat dæmoniis. Ergo cum id faciant qui ad scenam
+                        properant, in vitio sunt immani, quasi diabolo immolantes.</p><p>3. E culpa
+                        letali voluptatem capere, seu ex ea re quæ non est sine culpa letali, letale
+                        est crimen. Sed qui intersunt, Comœdiis obscœnis, voluptatem hauriunt ex
+                        actione Histrionum, quæ illis criminosa est. Ergo codem spectatores crimine
+                        inficiuntur.</p><p>4. Chrisitanæ Ecclesiæ doctores, sacræ Theologiæ
+                        Magistri, de spectatorum peccato, ut nos, sentiunt. Ergo nos secus credere,
+                        aut opinari fas non est.</p><p>Quinta via illorum Philosophorum est, qui
+                        Christianæ sapientiæ luce orbati fuerunt. Plato lib. 3. de Republica, in
+                        civitatem non vult recipi malarum turpiumve rerum Comœdiam, neque Comœdios
+                        ac Histriones. »</p></quote>
                   </note>,</seg> et S. Antonin lequel dit que ceux qui représentent des choses fort
                 sales, et lascives, commettent des péchés mortels : comme font aussi ceux qui
                 regardent volontairement ces représentations, parce que ce n’est autre chose que se
@@ -18094,123 +17778,77 @@
                   bêtes cessent entièrement en ce saint Jour. Que si la solennité qu’on célèbre au
                   jour de notre naissance, se rencontre en quelqu’une de ces Fêtes, qu’elle soit
                   remise à un autre jour.  »</quote>
-              </quote>
+              </quote><pb n="401" xml:id="p401"/>
             </p>
-            <p>
-              <pb n="401" xml:id="p401"/>
-              <quote>« Et parce que cette loi est juste, pour un sujet aussi important qu’est celui
+
+
+            <quote><p>« Et parce que cette loi est juste, pour un sujet aussi important qu’est celui
                 qui regarde l’établissement du culte de Dieu, qu’elle a été faite par un Empereur
                 légitime, et qu’elle a été reçue par toutes les Provinces de l’Empire, on ne la peut
                 mépriser sans commettre un crime. Richard dans ses Commentaires sur le 4. livre du
                 Maître des Sentences, infère de cette loi que selon les Docteurs, c’est un péché
-                mortel, de danser, et de faire des joutes les Dimanches. </quote>
-            </p>
-            <p>
-              <quote>« La quatrième preuve <seg type="exquote">(de Comitolus)</seg> comprend les
-                raisons tirées des principes de la Théologie, et de la philosophie morale...</quote>
-            </p>
-            <p>
-              <quote>« Et premièrement il faut prouver que ceux qui jouent des Comédies déshonnêtes,
-                commettent un crime. Et ensuite il faut prouver que ceux qui les vont écouter
-                commettent aussi un péché mortel.</quote>
-            </p>
-            <p>
-              <quote>« Voici les raisons qui regardent les Acteurs des Comédies.</quote>
-            </p>
-            <p>
-              <quote>« 1. Se priver soi-même, et les autres de la vertu, sans laquelle nul ne peut
-                obtenir de Dieu le salut éternel ; est un grand péché ; car il éteint la charité. Or
-                celui qui représente publiquement des choses déshonnêtes, se prive volontairement
-                soi-même, et les autres de la pureté de cœur, sans laquelle nul ne verra jamais
-                Dieu. Il commet donc un grand péché.</quote>
-            </p>
-            <p>
-              <quote>« 2. Celui qui détruit les fondements des villes, et des états bien réglés,
-                commet un très grand crime. Or les Acteurs des Comédies s’efforcent de le faire, en
-                bannissant des villes la pudeur, la modestie, la tempérance, et la chasteté. Ils
-                commettent donc un très grand crime.</quote>
-            </p>
-            <p>
-              <quote>« 3. Ceux qui corrompent la bonne éducation de la jeunesse, et qui l’empêchent
-                de se conduire avec l’honnêteté, et la décence que demande la vie civile ;
-                commettent un grand péché.</quote>
-            </p>
-            <p>
-              <quote>« C’est ce que font ces infâmes Acteurs de Comédies déshonnêtes. Ils commettent
-                donc un grand péché. </quote>
-            </p>
-            <p>
-              <quote>4. Il faut que ceux qui corrompent la véritable fin des Villes, et des Etats ;
-                aient les mœurs bien corrompues, et l’esprit bien vicieux. </quote>
-            </p>
-            <p>
-              <pb n="402" xml:id="p402"/>
-              <quote>« Or c’est ce que tâchent de faire les Mimes, les Comédiens, et les Bateleurs,
-                qui en foulant aux pieds la vertu, laquelle seule conduit à la félicité,
-                introduisent dans les Villes, le vice, l’oisiveté, et l’impureté. Car la fin de
-                toutes les justes Lois, de tous les sages Législateurs, et de tous les Etats, est de
-                rendre les Citoyens vertueux, afin que par la vertu ils puissent être
-                heureux.</quote>
-            </p>
-            <p>
-              <quote>« 5. Celui qui dans son action se propose quelque chose criminelle, commet un
-                crime. Or ceux qui divertissent et flattent les oreilles et les yeux des
-                spectateurs, et des auditeurs, par des Comédies, et des représentations déshonnêtes,
-                se proposent un plaisir criminel soit dans toute la Comédie, soit dans quelque
-                partie ; ils commettent donc un crime : et un crime de scandale actif comme parlent
-                les Théologiens, ou d’homicide spirituel.</quote>
-            </p>
-            <p>
-              <quote>« 6. Nul n’est privé par l’Eglise Chrétienne de la participation des
+                mortel, de danser, et de faire des joutes les Dimanches.</p><p>La quatrième preuve
+                  <seg type="exquote">(de Comitolus)</seg> comprend les raisons tirées des principes
+                de la Théologie, et de la philosophie morale...</p><p>Et premièrement il faut
+                prouver que ceux qui jouent des Comédies déshonnêtes, commettent un crime. Et
+                ensuite il faut prouver que ceux qui les vont écouter commettent aussi un péché
+                mortel.</p><p>Voici les raisons qui regardent les Acteurs des Comédies.</p><p>1. Se
+                priver soi-même, et les autres de la vertu, sans laquelle nul ne peut obtenir de
+                Dieu le salut éternel ; est un grand péché ; car il éteint la charité. Or celui qui
+                représente publiquement des choses déshonnêtes, se prive volontairement soi-même, et
+                les autres de la pureté de cœur, sans laquelle nul ne verra jamais Dieu. Il commet
+                donc un grand péché.</p><p>2. Celui qui détruit les fondements des villes, et des
+                états bien réglés, commet un très grand crime. Or les Acteurs des Comédies
+                s’efforcent de le faire, en bannissant des villes la pudeur, la modestie, la
+                tempérance, et la chasteté. Ils commettent donc un très grand crime.</p><p>3. Ceux
+                qui corrompent la bonne éducation de la jeunesse, et qui l’empêchent de se conduire
+                avec l’honnêteté, et la décence que demande la vie civile ; commettent un grand
+                péché.</p><p>C’est ce que font ces infâmes Acteurs de Comédies déshonnêtes. Ils
+                commettent donc un grand péché.</p><p>4. Il faut que ceux qui corrompent la
+                véritable fin des Villes, et des Etats ; aient les mœurs bien corrompues, et
+                l’esprit bien vicieux.<pb n="402" xml:id="p402"/></p><p>Or c’est ce que tâchent de
+                faire les Mimes, les Comédiens, et les Bateleurs, qui en foulant aux pieds la vertu,
+                laquelle seule conduit à la félicité, introduisent dans les Villes, le vice,
+                l’oisiveté, et l’impureté. Car la fin de toutes les justes Lois, de tous les sages
+                Législateurs, et de tous les Etats, est de rendre les Citoyens vertueux, afin que
+                par la vertu ils puissent être heureux.</p><p>5. Celui qui dans son action se
+                propose quelque chose criminelle, commet un crime. Or ceux qui divertissent et
+                flattent les oreilles et les yeux des spectateurs, et des auditeurs, par des
+                Comédies, et des représentations déshonnêtes, se proposent un plaisir criminel soit
+                dans toute la Comédie, soit dans quelque partie ; ils commettent donc un crime : et
+                un crime de scandale actif comme parlent les Théologiens, ou d’homicide
+                spirituel.</p><p>6. Nul n’est privé par l’Eglise Chrétienne de la participation des
                 Sacrements, que pour un crime digne de la damnation éternelle. Or ces Mimes, ces
                 Comédiens, et ces Bateleurs sont privés par l’Eglise de la participation des
-                Sacrements, ils commettent donc un crime digne de l’éternelle damnation.</quote>
-            </p>
-            <p>
-              <quote>« 7. Celui qui composerait un Poème, ou des vers d’amour, sans craindre
-                d’allumer dans les cœurs des Lecteurs le feu de l’impureté, commettrait un crime qui
-                blesserait grièvement l’amour qu’on doit à Dieu. Combien plus donc le blessent ceux
-                qui embrasent les cœurs des spectateurs des flammes des vices, non par un livre
-                inanimé qu’ils présentent à leurs yeux ; mais par leurs postures, par leurs gestes,
-                par leur visage et par leur voix qui ne respire que l’impureté, et qui brûle leurs
-                cœurs par des feux impudiques et honteux.</quote>
-            </p>
-            <p>
-              <quote>« 8. Les Acteurs de Comédies déshonnêtes, méprisent grandement Dieu, et ses
-                augustes lois : ils nuisent extrêmement aux spectateurs, et à eux-mêmes : ils
-                commettent donc un péché mortel.</quote>
-            </p>
-            <p>
-              <quote>« Enfin tant d’illustres Prélats, tant de doctes interprètes de notre Religion.
-                Tant de célèbres Théologiens ont condamné les Comédies déshonnêtes, et leurs
-                Acteurs, comme des choses très pernicieuses, et comme des objets de la <pb n="403"
-                  xml:id="p403"/> haine de Dieu. Il n’est pas donc permis de douter de l’énormité de
-                leur crime.</quote>
-            </p>
-            <p>
-              <quote>« Quant aux spectateurs voici les raisons qui font voir combien ils sont
+                Sacrements, ils commettent donc un crime digne de l’éternelle damnation.</p><p>7.
+                Celui qui composerait un Poème, ou des vers d’amour, sans craindre d’allumer dans
+                les cœurs des Lecteurs le feu de l’impureté, commettrait un crime qui blesserait
+                grièvement l’amour qu’on doit à Dieu. Combien plus donc le blessent ceux qui
+                embrasent les cœurs des spectateurs des flammes des vices, non par un livre inanimé
+                qu’ils présentent à leurs yeux ; mais par leurs postures, par leurs gestes, par leur
+                visage et par leur voix qui ne respire que l’impureté, et qui brûle leurs cœurs par
+                des feux impudiques et honteux.</p><p>8. Les Acteurs de Comédies déshonnêtes,
+                méprisent grandement Dieu, et ses augustes lois : ils nuisent extrêmement aux
+                spectateurs, et à eux-mêmes : ils commettent donc un péché mortel.</p><p>Enfin tant
+                d’illustres Prélats, tant de doctes interprètes de notre Religion. Tant de célèbres
+                Théologiens ont condamné les Comédies déshonnêtes, et leurs Acteurs, comme des
+                choses très pernicieuses, et comme des objets de la <pb n="403" xml:id="p403"/>
+                haine de Dieu. Il n’est pas donc permis de douter de l’énormité de leur
+                crime.</p><p>Quant aux spectateurs voici les raisons qui font voir combien ils sont
                 coupables. Premièrement, c’est un péché mortel, d’être cause que les autres
                 commettent un péché mortel. Or les spectateurs en assistant aux Comédies
                 déshonnêtes, sont cause que les Comédiens les représentent ; ils commettent donc un
-                péché mortel.</quote>
-            </p>
-            <p>
-              <quote>« 2. Donner de l’argent à ces sortes de Comédiens, est un vice énorme selon
-                saint Augustin, et c’est sacrifier aux démons selon Jérôme. Or ceux qui vont à la
-                Comédie, font cela ; ils s’engagent donc dans un vice aussi énorme que s’ils
-                sacrifiaient aux démons.</quote>
-            </p>
-            <p>
-              <quote>« 3. C’est un péché mortel, de trouver son plaisir dans un péché mortel, ou
-                dans une chose qui n’est point sans péché mortel. Or les spectateurs des Comédies
-                déshonnêtes trouvent leur plaisir dans l’action criminelle des Acteurs de ces
-                Comédies. Les spectateurs donc se rendent coupables du même crime.</quote>
-            </p>
-            <p>
-              <quote>« 4. C’est le commun sentiment des Docteurs de l’Eglise Chrétienne, et des
-                Théologiens touchant le péché des spectateurs, il n’est donc pas permis de nous en
-                éloigner. »</quote>
-            </p>
+                péché mortel.</p><p>2. Donner de l’argent à ces sortes de Comédiens, est un vice
+                énorme selon saint Augustin, et c’est sacrifier aux démons selon Jérôme. Or ceux qui
+                vont à la Comédie, font cela ; ils s’engagent donc dans un vice aussi énorme que
+                s’ils sacrifiaient aux démons.</p><p>3. C’est un péché mortel, de trouver son
+                plaisir dans un péché mortel, ou dans une chose qui n’est point sans péché mortel.
+                Or les spectateurs des Comédies déshonnêtes trouvent leur plaisir dans l’action
+                criminelle des Acteurs de ces Comédies. Les spectateurs donc se rendent coupables du
+                même crime.</p><p>4. C’est le commun sentiment des Docteurs de l’Eglise Chrétienne,
+                et des Théologiens touchant le péché des spectateurs, il n’est donc pas permis de
+                nous en éloigner. »</p></quote>
+
             <p>La cinquième preuve de Comitolus est tirée des Philosophes qui n’ont pas été éclairés
               de la lumière de la sagesse chrétienne. Il rapporte premièrement l’autorité de Platon,
               qui dans le troisième livre de la <hi rend="i">République</hi>
@@ -18256,10 +17894,9 @@
             <p>3. Il parle des Théâtres, et représente que les peuples ayant embrassé la Religion
               Chrétienne, les abattirent ; et que par conséquent la Religion Chrétienne ne permet
               point qu’on dresse de nouveau des Théâtres : il rapporte ensuite les diverses
-              descriptions que les Pères de l’Eglise ont fait des Théâtres. <quote>« Les uns<seg
-                  type="exquote">, dit-il<note place="margin" resp="author">
-                    <p>
-                      <quote>« Recibida ya la Christiana Religion, <hi rend="i">dize san
+              descriptions que les Pères de l’Eglise ont fait des Théâtres.</p>
+            <quote><p>« Les uns<seg type="exquote">, dit-il<note place="margin" resp="author">
+                    <quote><p>« Recibida ya la Christiana Religion, <hi rend="i">dize san
                           Augustin</hi>, casi per todas las ciudades, se van cayendo los theatros,
                         cuevas de torpeza, y de publica profession de maldades. Y nos otros hemos de
                         porfiar restaurar los ? Unos llaman à los theatros escuelas de vicios. <hi
@@ -18272,15 +17909,16 @@
                         Republica, fuentes, y manantiales de muchos males. <hi rend="i">Tertulliano
                           llama à los representationes</hi> fomentadoras de deshonestidad,
                         sangrientes, y lascivas, impias, y prodigas. Otros finalmente las llaman
-                        arte afrentosa, y de burla, y profession publica de toda maldad.</quote></p>
-                    <p><quote>« Son los theatros y representationes escuelas de vicios, que en ellos
-                        se deprenden por lo que antiquamente, y aora no pocas vezes se representa en
+                        arte afrentosa, y de burla, y profession publica de toda maldad.</p><p>Son
+                        los theatros y representationes escuelas de vicios, que en ellos se
+                        deprenden por lo que antiquamente, y aora no pocas vezes se representa en
                         ellos, que son adulterios incestos, sacrilegios, Homicidios, venganças,
                         ambiciones, y pretensiones, de honra contra razon, y derecho, fraudes, y
                         fieros hechas à sus amos enredos de Rameras, atreuimientos de rufianes, y
                         artes de terceras. Ven y oyen alli los oyentes hazer esto, ez salir con
-                        esto, y assi falon ellos tambien aficionados ò enseñados à esto. »</quote>
-                      Discurso 6. §.11.</p>
+                        esto, y assi falon ellos tambien aficionados ò enseñados à
+                      esto. »</p></quote>
+                    <p>Discurso 6. §.11.</p>
                   </note>,</seg>
                 <hi rend="i">appellent les Théâtres</hi> les écoles des vices : <hi rend="i"
                   >D’autres les appellent</hi> des Chaires de pestilence, et d’erreur : <hi rend="i"
@@ -18294,19 +17932,17 @@
                   >Tertullien dit que les Comédies sont des représentations</hi> qui entretiennent
                 l’impudicité, la cruauté, la débauche, l’impiété, et la prodigalité. <hi rend="i"
                   >D’autres enfin disent</hi> que c’est un art infâme de bouffonnerie, et de
-                fourberie, et d’effronterie, une profession publique de toute
-              méchanceté.</quote></p>
-            <p>
-              <quote>« Les Théâtres <seg type="exquote">, ajoute-t-il,</seg> et les représentations
-                sont les écoles des vices qui y sont représentés, comme on les y représentait
-                anciennement ; et comme on y représente encore aujourd’hui très souvent, des
-                adultères, des incestes, des sacrilèges, des homicides, des vengeances, des excès
-                d’ambition, et des prétentions d’honneur contre la raison, et le droit : Des
-                tromperies, et des fourberies que les valets, et les serviteurs font à leurs
-                Maîtres : Des tours des femmes débauchées, des ruses, et des artifices de
-                maquerellage. Ceux qui voient et qui entendent ces choses, se retirent ou passionnés
-                pour ces choses, ou instruits à les faire. »</quote>
-            </p>
+                fourberie, et d’effronterie, une profession publique de toute méchanceté.</p><p>Les
+                Théâtres <seg type="exquote">, ajoute-t-il,</seg> et les représentations sont les
+                écoles des vices qui y sont représentés, comme on les y représentait anciennement ;
+                et comme on y représente encore aujourd’hui très souvent, des adultères, des
+                incestes, des sacrilèges, des homicides, des vengeances, des excès d’ambition, et
+                des prétentions d’honneur contre la raison, et le droit : Des tromperies, et des
+                fourberies que les valets, et les serviteurs font à leurs Maîtres : Des tours des
+                femmes débauchées, des ruses, et des artifices de maquerellage. Ceux qui voient et
+                qui entendent ces choses, se retirent ou passionnés pour ces choses, ou instruits à
+                les faire. »</p></quote>
+
             <p>4. Le Père Guzman rapporte ensuite plusieurs passages des anciens Pères qui
               condamnent les Comédies, et les autres spectacles : On les peut voir ci-dessus dans
               nos Réfutations et dans le <hi rend="i">Traité de la Comédie, et des Spectacles</hi>
@@ -18315,54 +17951,53 @@
               part des choses qui y sont représentées. 2. De la part des femmes qui paraissent sur
               le Théâtre. 3. De la part des assemblées.</p>
             <p>Quant au danger qui vient des choses qui sont représentées : <quote>« Je dis<seg
-                  type="exquote">, dit-il<note place="margin" resp="author"><p>
-                      <quote>« Digo que lo que mas da à entender el damno de los theatros, es llamar
-                        los lugares de peligro, deslizaderos de las consciencias, y laços de las
-                        almas. Y cierto un ciego, sino lo esta mucho con la passion, echara de ver
-                        el gravissimo peligro, que en estos tan malos passos ay, y rehuzara, si
+                  type="exquote">, dit-il<note place="margin" resp="author">
+                    <quote><p>« Digo que lo que mas da à entender el damno de los theatros, es
+                        llamar los lugares de peligro, deslizaderos de las consciencias, y laços de
+                        las almas. Y cierto un ciego, sino lo esta mucho con la passion, echara de
+                        ver el gravissimo peligro, que en estos tan malos passos ay, y rehuzara, si
                         tiene algun genero de temor de su damno, passar por aqui. Sino diga me
-                        qualquier desapassionado, y que juzga de las cosas
-                        bien :</quote></p><p><quote>« Que cosa mas peligrosa, que poner de lante de
-                        los oios, cuyos objetos tienen tanta fuerça, y poder con el alma, y negotian
-                        tan presto con ella loque quieren, un euredo de amor, una pretension
-                        deshonesta, ò de vengança, ò de ambicion començada, mediada, y acabada con
-                        grande artificio, con multa à gudoza, e ingenio, con palabras discretas,
-                        representando con acciones vivas, con pronunciacion suave, y con aparato, y
-                        representacion grave ? <quote>« El Christiano<seg type="exquote">, dize san
-                            Cypriano,</seg> à quien no es licito pensar en los vicios, que haze à
-                          qui uriendo los tan al vivo »</quote>, y como en su mismo ser ? Idem §.
-                        4.</quote></p><p><quote>« Pues que si se llega à esto lo que tiene damno, y
-                        peligro, particular à parte, y por si y el mayor que en esta materia ay, es
-                        salir à representar, y à tañer, y cantar, y baylar una muger, compuesta,
-                        afeitada, y affectada, lasciva, y desambuelta, y de buena gracia, y buen
-                        parecer, y que como tiene y à rompida la verguença, que suele ser tan
-                        natural en las mugores, habla en publico sin ella, canta, bayla, y
-                        representa, ya una Reyna, ya una Ramera, y en el entremes, ya en la Comedia,
-                        ya compuesta, ya descompuesta ; pero siempre libre, y pocas vezes honesta ;
-                        ya se muestra esquiva, ya affable, ya çahareña, ya blanda, y suave, todo con
-                        fin solo de agradar, y parecer bien. Si las sandalias solas de Judith
-                        bastaron à arrebatar los oyos del otro ferocissimo Capitan, y su hermosura
-                        le cautivo el alma ; que hara el rostro, y los braços, y los pies, y el
-                        talle, y el donayre, y el bayle de la que sale à representar y à presentar
-                        su persona de lante de loxoios de un moço poco recatado, y que no tiene
-                        armado el pecho, ny echo à exercicios de guerra, como lo tenia Holofernes,
-                        sino quiça hecho blanco, y terreto de las saetas del torpe
-                      amor. »</quote></p></note>,</seg> qu’on ne saurait mieux faire entendre
-                combien les Théâtres sont nuisibles, qu’en disant que ce sont des lieux dangereux,
-                des précipices glissants de consciences, des pièges des âmes. Certes il faudrait
-                être bien aveuglé par sa passion pour ne pas apercevoir le danger qu’il y a dans ces
-                mauvais passages ; et il faudrait n’avoir <pb n="406" xml:id="p406"/>aucune
-                appréhension de sa perte, pour ne pas se garder de passer par là. Qu’un homme sans
-                passion, et qui juge bien des choses me dise s’il y a rien de plus dangereux, que de
-                représenter aux yeux, des objets qui ont tant de force, et tant de pouvoir sur
-                l’âme, et qui obtiennent d’elle si promptement ce qu’ils veulent : des intrigues
-                d’amour, des prétentions déshonnêtes ou de vengeance ou d’ambition, qu’on commence,
-                qu’on continue, et qu’on achève avec beaucoup d’artifice, d’adresse, et d’esprit,
-                qu’on accompagne de belles paroles, qu’on représente avec des actions vives, avec
-                une prononciation agréable, et avec gravité. <quote>« Un Chrétien, <seg
-                    type="exquote">dit S. Cyprien</seg>, à qui il n’est pas même permis d’avoir une
-                  pensée des vices ? que fait-il là, où il les voit d’une manière vive, et tels
-                  qu’ils sont en eux-mêmes. »</quote>. »</quote></p>
+                        qualquier desapassionado, y que juzga de las cosas bien :</p><p>Que cosa mas
+                        peligrosa, que poner de lante de los oios, cuyos objetos tienen tanta
+                        fuerça, y poder con el alma, y negotian tan presto con ella loque quieren,
+                        un euredo de amor, una pretension deshonesta, ò de vengança, ò de ambicion
+                        començada, mediada, y acabada con grande artificio, con multa à gudoza, e
+                        ingenio, con palabras discretas, representando con acciones vivas, con
+                        pronunciacion suave, y con aparato, y representacion grave ? <quote>« El
+                            Christiano<seg type="exquote">, dize san Cypriano,</seg> à quien no es
+                          licito pensar en los vicios, que haze à qui uriendo los tan al
+                          vivo »</quote>, y como en su mismo ser ? Idem §. 4.</p><p>Pues que si se
+                        llega à esto lo que tiene damno, y peligro, particular à parte, y por si y
+                        el mayor que en esta materia ay, es salir à representar, y à tañer, y
+                        cantar, y baylar una muger, compuesta, afeitada, y affectada, lasciva, y
+                        desambuelta, y de buena gracia, y buen parecer, y que como tiene y à rompida
+                        la verguença, que suele ser tan natural en las mugores, habla en publico sin
+                        ella, canta, bayla, y representa, ya una Reyna, ya una Ramera, y en el
+                        entremes, ya en la Comedia, ya compuesta, ya descompuesta ; pero siempre
+                        libre, y pocas vezes honesta ; ya se muestra esquiva, ya affable, ya
+                        çahareña, ya blanda, y suave, todo con fin solo de agradar, y parecer bien.
+                        Si las sandalias solas de Judith bastaron à arrebatar los oyos del otro
+                        ferocissimo Capitan, y su hermosura le cautivo el alma ; que hara el rostro,
+                        y los braços, y los pies, y el talle, y el donayre, y el bayle de la que
+                        sale à representar y à presentar su persona de lante de loxoios de un moço
+                        poco recatado, y que no tiene armado el pecho, ny echo à exercicios de
+                        guerra, como lo tenia Holofernes, sino quiça hecho blanco, y terreto de las
+                        saetas del torpe amor. »</p></quote></note>,</seg> qu’on ne saurait mieux
+                faire entendre combien les Théâtres sont nuisibles, qu’en disant que ce sont des
+                lieux dangereux, des précipices glissants de consciences, des pièges des âmes.
+                Certes il faudrait être bien aveuglé par sa passion pour ne pas apercevoir le danger
+                qu’il y a dans ces mauvais passages ; et il faudrait n’avoir <pb n="406"
+                  xml:id="p406"/>aucune appréhension de sa perte, pour ne pas se garder de passer
+                par là. Qu’un homme sans passion, et qui juge bien des choses me dise s’il y a rien
+                de plus dangereux, que de représenter aux yeux, des objets qui ont tant de force, et
+                tant de pouvoir sur l’âme, et qui obtiennent d’elle si promptement ce qu’ils
+                veulent : des intrigues d’amour, des prétentions déshonnêtes ou de vengeance ou
+                d’ambition, qu’on commence, qu’on continue, et qu’on achève avec beaucoup
+                d’artifice, d’adresse, et d’esprit, qu’on accompagne de belles paroles, qu’on
+                représente avec des actions vives, avec une prononciation agréable, et avec gravité.
+                  <quote>« Un Chrétien, <seg type="exquote">dit S. Cyprien</seg>, à qui il n’est pas
+                  même permis d’avoir une pensée des vices ? que fait-il là, où il les voit d’une
+                  manière vive, et tels qu’ils sont en eux-mêmes. »</quote>. »</quote></p>
             <p>Quant au danger qui vient de la part des femmes qui paraissent sut le Théâtre :</p>
             <p>
               <quote>« Ajoutons à cela, <seg type="exquote">dit-il,</seg> qu’il y a une autre chose
@@ -18389,24 +18024,20 @@
             <p>Guzman allègue à ce propos les paroles de Saint Chrysostome que j’ai rapportées
               ci-dessus dans le XIV. Siècle.</p>
             <p>Il cite ensuite ces passages de l’Ecclésiastique<note place="margin" resp="author"><p>
-                  <hi rend="i">Ecclesiast. 4. v. 3. 4. 5. et 9</hi>. <quote>« Ne respicias mulierem
-                    multivolam, ne forte incidas in laqueos illius. Cum saltatrice ne assiduus sis,
-                    nec audias illam, ne forte pereas in efficacia
-                    illius.</quote></p><p> «<quote>Virginem ne conspicias, ne forte scandalizeris in
-                    decore illius.</quote> </p><p><quote>« Averte faciem tuam a muliere compta,
-                    propter speciem mulieris multi perierunt. Et ex hoc concupiscentia tanquam ignis
-                    inardescit. »</quote></p></note> : <quote>« Ne jetez pas les yeux sur une femme
-                débauchée, de peur de tomber dans ses pièges</quote>.</p>
-            <p>
-              <quote>« Ne fréquentez point ces femmes qui font profession de danser, et de bien
-                chanter, de peur que leurs attraits ne vous perdent.</quote>
-            </p>
-            <p>
-              <quote>« Ne regardez point une jeune fille, de peur que sa beauté ne vous soit un
-                sujet de scandale, et de chute.</quote>
-            </p>
-            <p><quote>« Détournez vos yeux d’une femme bien parée, la beauté d’une femme a fait
-                périr plusieurs hommes. C’est ce qui allume le feu de la concupiscence. »</quote>   </p>
+                  <hi rend="i">Ecclesiast. 4. v. 3. 4. 5. et 9</hi>.</p><quote><p>« Ne respicias
+                    mulierem multivolam, ne forte incidas in laqueos illius. Cum saltatrice ne
+                    assiduus sis, nec audias illam, ne forte pereas in efficacia
+                    illius.</p><p>Virginem ne conspicias, ne forte scandalizeris in decore
+                    illius.</p><p>Averte faciem tuam a muliere compta, propter speciem mulieris
+                    multi perierunt. Et ex hoc concupiscentia tanquam ignis
+                  inardescit. »</p></quote></note> :</p>
+            <quote><p>« Ne jetez pas les yeux sur une femme débauchée, de peur de tomber dans ses
+                pièges.</p><p>Ne fréquentez point ces femmes qui font profession de danser, et de
+                bien chanter, de peur que leurs attraits ne vous perdent.</p><p>Ne regardez point
+                une jeune fille, de peur que sa beauté ne vous soit un sujet de scandale, et de
+                chute.</p><p>Détournez vos yeux d’une femme bien parée, la beauté d’une femme a fait
+                périr plusieurs hommes. C’est ce qui allume le feu de la
+              concupiscence. »</p></quote>
             <p>Et après avoir allégué plusieurs autres endroits de l’Ecriture, et des Pères sur ce
               sujet, il adresse aux curieux ces paroles de S. Chrysostome<note place="margin"
                 resp="author"> Chrysostomus homil. 1. in psalm. 50. <quote>« Audiant curiosi qui
@@ -18419,17 +18050,16 @@
             <p>
               <quote>« Puisque David qui était un si grand personnage <note resp="author"
                   place="margin">
-                  <p><quote>« Pues como David, siendo quien era, tan gran varon, tan gran santo
+                  <quote><p>« Pues como David, siendo quien era, tan gran varon, tan gran santo
                       recivio damno. <hi rend="i">Et te putas non posse ludi ?</hi> Y el en la
                       solana ò corredor de su casa, y tu en el theatro, <quote>« Ubi et locus
                         condemnat animam sapientis.</quote>El tan lexos ; y tu tan cerca ; el no
                       pensando su damno ; tu yendole à buscar : adonde ay tantos peligros, tantos
                       precipicios, tantas occasiones de caër, como heyo de presumir sales sin
                       peccado ? <quote>« Numquid lapideus es aut ferreus ? Igni conjungeris ; et non
-                        ardebis ? »</quote></quote></p><p><quote>« Pues aunque lo seas, advierte que
-                      el fuego riude la piedra, y el hierro.</quote></p>
-                  <p><quote>« San Nilo Abad entre los remedios de luxuria, pone huyr de
-                      espectaculos, aunque sea dize, para celebrar fiestas de santos :
+                        ardebis ? »</quote></p><p>Pues aunque lo seas, advierte que el fuego riude
+                      la piedra, y el hierro.</p><p>San Nilo Abad entre los remedios de luxuria,
+                      pone huyr de espectaculos, aunque sea dize, para celebrar fiestas de santos :
                         <quote>« Satius est enim domi maneus quam dum putas te celebritates
                         venerari, in manu inimicorum incidere. »</quote> Y lo cierto en esta
                       materia, es lo que el Espiritu santo dize : <quote>« Qui amat periculum in
@@ -18438,8 +18068,8 @@
                       caëra, yendo à alguna parte peligrosa, pecca mortalmente, aunantes que cuya, y
                       ya va à ella, porque ya se mette en el peligro, y le quiere. Y desir, y pensar
                       que el Theatro, donde estas mugeres representan, y otras assisten, no es lugar
-                      peligroso, es ignorancia, ò demasiada confiança. Idem §. 4.</quote></p>
-                  <p><quote>« Et sin duda ninguna, una muger que sale à representar galana y
+                      peligroso, es ignorancia, ò demasiada confiança. Idem §. 4.</p></quote>
+                  <quote><p>« Et sin duda ninguna, una muger que sale à representar galana y
                       vistosa, como la serpiente llamada scitale, de quien dizen Solino, y san
                       Isidoro es tan hermosa, y de tan doradas pintadas, y resplandecientes oscamas,
                       que arrebatan la vista, y tras ella el coraçon, y aficion del que la mira…Pero
@@ -18451,26 +18081,24 @@
                         simpliciter qua ibi fiunt, turpissima sunt, verba, vestitus, tonsura,
                         incessus, voces, cantus, modulationes, oculorum, conversiones, ac motus,
                         tibiæ, fistulæ, et ipsa fabulosa argumentatio. »</quote> S. Chrysost. hom.
-                      38. in Math. Ibid.</quote></p>
-                  <p><quote>« Uno de otros daños es, la ocasion y licencia que da el mismo theatro,
-                      ò jugar, adonde tanta gente se junta, y adonde como dixo el otro califiando à
-                      Athenas, todo se tiene por honesto, por menos honesto que sea, el mirar, el
-                      hablar, el reyr, el hazer sennas, embiar recaudos, villetes, regalos,
-                      colaciones, meriendas, aloias….</quote></p><p><quote>« El otro daño es la
-                      perdida del tiempo que gastan assy representantes, como oyentes en un
-                      entretenimiento, que fuera malo, aunque solo tuviera ociosidad….</quote></p>
-                  <p><quote>« O tiempo preciosissimo, medida de nuestra vida, dado para negociar la
-                      eterna, para el estudio de lasabiduria, para los exercitios de la virtud, que
-                      prodigamente, te gastan los hombres ! »</quote> §. 6.</p></note> un si saint
-                homme en fut blessé ; pensez-vous que ces objets ne vous puissent faire aucun mal ?
-                David était sur le haut de sa maison ; et vous êtes dans le Théâtre ; qui est un
-                lieu, où un homme sage ne se peut trouver sans se rendre coupable . David était
-                éloigné de la femme qu’il aperçut, et vous en êtes si proche : Il ne pensait point à
-                sa perte ; et vous l’allez chercher, où il y a tant de dangers, tant de précipices,
-                tant de sujets de chute. Comment pourrais-je présumer que vous en sortiez sans
-                péché ? Etes-vous de pierre, ou de fer, pour vous jeter dans le feu sans vous
-                bruler ? Et quand bien vous le seriez : ne savez-vous pas que le feu consume les
-                pierres, et le fer ? </quote>
+                      38. in Math. Ibid.</p><p>Uno de otros daños es, la ocasion y licencia que da
+                      el mismo theatro, ò jugar, adonde tanta gente se junta, y adonde como dixo el
+                      otro califiando à Athenas, todo se tiene por honesto, por menos honesto que
+                      sea, el mirar, el hablar, el reyr, el hazer sennas, embiar recaudos, villetes,
+                      regalos, colaciones, meriendas, aloias….</p><p>El otro daño es la perdida del
+                      tiempo que gastan assy representantes, como oyentes en un entretenimiento, que
+                      fuera malo, aunque solo tuviera ociosidad….</p><p>O tiempo preciosissimo,
+                      medida de nuestra vida, dado para negociar la eterna, para el estudio de
+                      lasabiduria, para los exercitios de la virtud, que prodigamente, te gastan los
+                      hombres ! »</p></quote><p> §. 6.</p></note> un si saint homme en fut blessé ;
+                pensez-vous que ces objets ne vous puissent faire aucun mal ? David était sur le
+                haut de sa maison ; et vous êtes dans le Théâtre ; qui est un lieu, où un homme sage
+                ne se peut trouver sans se rendre coupable . David était éloigné de la femme qu’il
+                aperçut, et vous en êtes si proche : Il ne pensait point à sa perte ; et vous
+                l’allez chercher, où il y a tant de dangers, tant de précipices, tant de sujets de
+                chute. Comment pourrais-je présumer que vous en sortiez sans péché ? Etes-vous de
+                pierre, ou de fer, pour vous jeter dans le feu sans vous bruler ? Et quand bien vous
+                le seriez : ne savez-vous pas que le feu consume les pierres, et le fer ? </quote>
             </p>
             <p>
               <pb n="408" xml:id="p408"/>
@@ -18505,7 +18133,7 @@
                   représentations malheureuses, ne porte qu’au mal : les paroles, les habits, la
                   frisure des cheveux, le marcher, la voix, les chants, les regards des yeux, les
                   mouvements du corps, le son des instruments, les sujets mêmes, et les intrigues
-                  des Comédies, tout y est plein de poison, tout y respire l’impureté. »</quote>. »
+                  des Comédies, tout y est plein de poison, tout y respire l’impureté. ». »</quote>
               </quote>
             </p>
             <p><pb n="409" xml:id="p409"/>3. Quant au danger qui vient des assemblées du Théâtre ;
@@ -18517,7 +18145,7 @@
             <p>
               <quote>« 4. L’autre mal est la perte du temps, que les Comédiens et leurs Spectateurs
                 passent dans un divertissement, qui serait mauvais, quand il n’aurait d’autre vice
-                que celui de l’oisiveté...</quote>
+                que celui de l’oisiveté... »</quote>
             </p>
             <p>
               <quote>« O temps, qui es si précieux, et qui es la mesure de notre vie, qui nous es
@@ -18602,7 +18230,7 @@
                     Petrarcha. »</quote></p></note> : <quote>« Notre nature corrompue, et vicieuse a
                 d’elle-même plus de pente à tomber qu’à s’élever ; si elle est donc poussée en bas
                 avec effort comme elle l’est à la Comédie ; comment ne tombera-t-elle pas, quand
-                même elle serait dans le plus haut état de la vertu ?</quote></p>
+                même elle serait dans le plus haut état de la vertu ? »</quote></p>
             <p>
               <quote>« La vue des Spectacles <seg type="exquote">dit saint Thomas (2. 2. q. 167.
                   art. 2. ad 2.)</seg> est vicieuse en ce qu’en regardant les choses qui y sont
@@ -18686,23 +18314,22 @@
                 aucun mal ? Mais n’est-ce pas un assez grand mal que d’employer si inutilement un si
                 long temps, et d’être aux autres un sujet de scandale ? »</quote>
             </p>
-            <p> «  <quote>Et pour faire entendre encore qu’il y a plus de mal qu’on ne pense, dans
-                les Comédies, il suffit d’ajouter ce que dit ce même Saint en un autre endroit :
+            <p>
+              <quote>« Et pour faire entendre encore qu’il y a plus de mal qu’on ne pense, dans les
+                Comédies, il suffit d’ajouter ce que dit ce même Saint en un autre endroit :
                   <quote>« Les Théâtres causent de grands maux aux Villes. Oui ces maux sont
-                  grands ; et cependant nous ne le comprenons pas</quote>....</quote>
+                  grands ; et cependant nous ne le comprenons pas</quote>.... »</quote>
             </p>
             <p>
-              <quote>«  <quote>« Les jeunes filles y apprennent à avoir moins de pudeur : les jeunes
-                  hommes deviennent impudents, et effrontés : les vieillards retombent dans la
-                  débauche" : de là viennent les malheurs, et les désordres des mariages, les
-                  larcins, les péculats <note place="bottom" resp="editor">[NDE] péculat = vol des
-                    biens publics.</note> , et une infinité d’autres crimes inconnus aux siècles
-                  passés.</quote></quote>
+              <quote>« Les jeunes filles y apprennent à avoir moins de pudeur : les jeunes hommes
+                deviennent impudents, et effrontés : les vieillards retombent dans la débauche" : de
+                là viennent les malheurs, et les désordres des mariages, les larcins, les péculats
+                  <note place="bottom" resp="editor">[NDE] péculat = vol des biens publics.</note> ,
+                et une infinité d’autres crimes inconnus aux siècles passés.</quote>
             </p>
             <p>
-              <quote>« Je dis en second lieu, ce que dit Pierre Grégoire de </quote>
-              <pb n="412" xml:id="p412"/>
-              <quote>Toulouse dans son recueil du Droit ; et ce qu’un Conseiller de Conseil Royal,
+              <quote>« Je dis en second lieu, ce que dit Pierre Grégoire de<pb n="412" xml:id="p412"
+                /> Toulouse dans son recueil du Droit ; et ce qu’un Conseiller de Conseil Royal,
                 personnage grave, et zélé pour le bien de l’Etat, docte et pieux, quoique homme
                 d’épée, remontra au Roi Philippe second, de glorieuse mémoire, dans le mémorial
                 qu’il lui présenta, qu’il n’y a rien de plus nuisible à l’Etat, que de dissimuler le
@@ -18864,11 +18491,10 @@
                 couvre l’hameçon auquel il est attaché ; Et l’expérience nous apprend que les hommes
                 ne se perdent que par l’amour de la volupté : <quote>« Si rien d’illicite ne leur
                   plaisait <seg type="exquote">, dit S. Augustin</seg>
-                </quote>
-                <note place="margin" resp="author"><quote>« Nemo peccaret, si nihil illicitum
-                    delectaret. »</quote> S. August. lib. 22. contra Faustum cap. 28.</note>
-                <quote> , ils ne pêcheraient jamais »</quote> ; et si le mal ne se glissait sous
-                l’apparence du plaisir, il n’entrerait jamais dans leurs âmes.</quote>
+                  <note place="margin" resp="author"><quote>« Nemo peccaret, si nihil illicitum
+                      delectaret. »</quote> S. August. lib. 22. contra Faustum cap. 28.</note> , ils
+                  ne pêcheraient jamais »</quote> ; et si le mal ne se glissait sous l’apparence du
+                plaisir, il n’entrerait jamais dans leurs âmes.</quote>
             </p>
             <p>
               <quote>« Or la Comédie est le plus charmant de tous les divertissements : Elle ne
@@ -18917,12 +18543,11 @@
                 lui prêtent des armes pour combattre la vertu qu’ils veulent défendre. C’est
                 pourquoi je détournerai toujours les Chrétiens de la Comédie : Je leur conseillerai
                 d’éviter un écueil qui étant plus dangereux qu’agréable, fait faire souvent un
-                triste naufrage à la chasteté ; Et me retranchant dans la raison de saint
-                Cyprien</quote>
-              <note place="margin" resp="author"><quote>« Prohibuit spectari quæ prohibuit
-                  fieri. »</quote> S. Cyprian. <hi rend="i">de spectac.</hi></note>
-              <quote>, je leur dirai que le Fils de Dieu leur a défendu de regarder ce qu’il leur a
-                défendu de commettre. »</quote>
+                triste naufrage à la chasteté ; Et me retranchant dans la raison de saint Cyprien
+                  <note place="margin" resp="author"><quote>« Prohibuit spectari quæ prohibuit
+                    fieri. »</quote> S. Cyprian. <hi rend="i">de spectac.</hi></note>, je leur dirai
+                que le Fils de Dieu leur a défendu de regarder ce qu’il leur a défendu de
+                commettre. »</quote>
             </p>
             <p><pb n="419" xml:id="p419"/>Monseigneur le Prince de Conti avait eu en sa jeunesse
               tant de passion pour la Comédie, qu’il entretint longtemps à sa suite une troupe de
@@ -19300,32 +18925,26 @@
                   point là l’esprit de ceux qui sont appelés à une vie céleste, dont les noms sont
                   déjà écrits dans cette éternelle Cité, et qui font profession d’une milice toute
                   spirituelle : mais c’est l’esprit de ceux qui combattent sous les enseignes du
-                  démon.</quote></p>
-              <p>
-                <quote>« Oui, mes frères, <seg type="exquote">ajoute ce Saint,</seg> c’est le démon
-                  qui a fait un art de ces divertissements et de ces jeux, pour attirer à lui les
-                  soldats de Jésus-Christ, et pour relâcher toute la vigueur, et comme les nerfs de
-                  leur vertu. C’est pour ce sujet qu’il a fait dresser des Théâtres dans les places
-                  publiques ; et qu’exerçant et formant lui-même ces bouffons, il s’en sert comme
-                  d’une peste dont il infecte toute la ville. Saint Paul nous a défendu les paroles
-                  impertinentes, et celles qui ne tendent qu’à un vain divertissement : mais le
-                  démon nous persuade d’aimer les unes et les autres.</quote>
-              </p>
-              <p>
-                <quote>« Ce qui est encore plus dangereux est le sujet pour lequel on s’emporte dans
-                  ces ris immodérés. Car aussitôt que ces bouffons ridicules ont proféré quelque
-                  blasphème, ou quelque parole déshonnête, on voit que les plus fous sont ravis de
-                  joie, et s’emportent dans des éclats de rire. Ils leur applaudissent pour des
-                  choses pour lesquelles on les devrait lapider : et ils s’attirent ainsi sur
-                  eux-mêmes, par ce détestable plaisir, le supplice d’un feu éternel. Car en les
-                  louant de ces folies, on leur persuade de les faire, et on se rend encore plus
-                  digne qu’eux de la condamnation qu’ils ont méritée. Si tout le monde s’accordait à
-                  ne vouloir point regarder leurs sottises, ils cesseraient bientôt de les faire.
-                  Mais lorsqu’ils vous voient tous les jours quitter vos occupations, vos travaux,
-                  et l’argent qui vous en revient, en un mot renoncer à tout pour assister à ces
-                  spectacles, ils redoublent leur ardeur, et ils s’appliquent bien davantage à ces
-                  niaiseries. »</quote>
-              </p>
+                  démon.<lb/>Oui, mes frères, <seg type="exquote">ajoute ce Saint,</seg> c’est le
+                  démon qui a fait un art de ces divertissements et de ces jeux, pour attirer à lui
+                  les soldats de Jésus-Christ, et pour relâcher toute la vigueur, et comme les nerfs
+                  de leur vertu. C’est pour ce sujet qu’il a fait dresser des Théâtres dans les
+                  places publiques ; et qu’exerçant et formant lui-même ces bouffons, il s’en sert
+                  comme d’une peste dont il infecte toute la ville. Saint Paul nous a défendu les
+                  paroles impertinentes, et celles qui ne tendent qu’à un vain divertissement : mais
+                  le démon nous persuade d’aimer les unes et les autres.<lb/>Ce qui est encore plus
+                  dangereux est le sujet pour lequel on s’emporte dans ces ris immodérés. Car
+                  aussitôt que ces bouffons ridicules ont proféré quelque blasphème, ou quelque
+                  parole déshonnête, on voit que les plus fous sont ravis de joie, et s’emportent
+                  dans des éclats de rire. Ils leur applaudissent pour des choses pour lesquelles on
+                  les devrait lapider : et ils s’attirent ainsi sur eux-mêmes, par ce détestable
+                  plaisir, le supplice d’un feu éternel. Car en les louant de ces folies, on leur
+                  persuade de les faire, et on se rend encore plus digne qu’eux de la condamnation
+                  qu’ils ont méritée. Si tout le monde s’accordait à ne vouloir point regarder leurs
+                  sottises, ils cesseraient bientôt de les faire. Mais lorsqu’ils vous voient tous
+                  les jours quitter vos occupations, vos travaux, et l’argent qui vous en revient,
+                  en un mot renoncer à tout pour assister à ces spectacles, ils redoublent leur
+                  ardeur, et ils s’appliquent bien davantage à ces niaiseries. »</quote></p>
               <p>Vous voyez, ma Sœur, que S. Chrysostome, aussi bien que Tertullien, ne condamne pas
                 seulement les Comédies à cause de leur dissolution et de leur impureté, mais encore
                 à cause qu’il n’est pas permis aux Chrétiens de passer le temps dans les ris, dans
@@ -19543,9 +19162,9 @@
                 on tombe sensiblement, les chutes de l’âme sont longues, elles ont des progrès et
                 des préparations ; et il arrive souvent qu’on ne succombe à des tentations, que
                 parce qu’on s’est affaibli en des occasions qui ont paru de nulle importance ; étant
-                certain que celui qui méprise les petites choses, s’engage peu à peu à tomber : « 
-                  <quote>qui spernit modica, paulatim decidet »</quote>. C’est un des sens de cette
-                parole de Job, <quote>« Qui habitant domos luteas consumentur velut a
+                certain que celui qui méprise les petites choses, s’engage peu à peu à
+                  tomber : <quote>«  qui spernit modica, paulatim decidet »</quote>. C’est un des
+                sens de cette parole de Job, <quote>« Qui habitant domos luteas consumentur velut a
                   tinea. »</quote> Ce qui marque que ceux qui vivent de la vie des sens, et dans les
                 plaisirs du monde, sont souvent consumés par des passions, <pb n="441" xml:id="p441"
                 />dont l’effet est insensible au commencement, comme celui de la tigne<note
@@ -20032,7 +19651,7 @@
                 que la Comédie, et les Romans tiennent le premier rang ; parce qu’il n’y a rien de
                 plus opposé à la vérité ; et que l’esprit de Dieu, comme dit S. Bernard, étant un
                 esprit de vérité, ne peut avoir de part avec la vanité du monde : <quote>« Sed nec
-                  erit ei unquam pars cum mundi vanitate, cum veritatis sit spiritus</quote>. »</p>
+                  erit ei unquam pars cum mundi vanitate, cum veritatis sit spiritus. »</quote></p>
               <p>XXVIII. Dieu ne nous impute pas les froideurs qui viennent de la soustraction de
                 ses lumières, ou simplement de la pesanteur du corps ; mais il nous impute sans
                 doute celles auxquelles nous avons contribué pas notre négligence et nos vains
@@ -20516,7 +20135,7 @@
                 âmes que la vérité Chrétienne et la charité ont guéries : elles rétablissent
                 l’idolâtrie, qui est l’origine du Théâtre, selon Tertullien<note place="margin"
                   resp="author"><quote>« Aeque spectaculis vestris in tantum renunciamus, in quantum
-                    originibus eorum quas scimus de superstitionibus esse conceptas</quote>. »
+                    originibus eorum quas scimus de superstitionibus esse conceptas. »</quote>
                   Tertull. Apolog. 28 [Tertullien, <hi rend="i">Apologétique</hi>, chap. 28]
                 </note>, et renversent le Royaume de Jésus-Christ autant qu’elles le peuvent faire.
                 Des hommes et des femmes déclarés infâmes par le Concile 7. de Carthage, et
@@ -20894,7 +20513,7 @@
                       21. de civit. Dei cap. ult. <quote>« Qua sint, inquit, ipsa peccata quæ ita
                         impediunt perventionem ad regnum Dei, ut tamen sanctorum amicorum meritis
                         impetrent indulgentiam, difficilissimum est invenire, periculosissimum
-                        definire.</quote></quote></p>
+                        definire. »</quote> »</quote></p>
                   <p><quote>« Ego certe usque ad hoc tempus cum inde satagerem, ad eorum indaginem
                       pervenire non potui. Et fortassis propterea latent, ne studium proficiendi ad
                       omnia peccata cavenda pigrescat. »</quote> Gaugericus Hisp. In annot. suis in
@@ -20942,12 +20561,12 @@
                 ceux qui ont soin de leur salut, doivent estimer qu’il y a péché mortel, pour la
                 sûreté de leur conscience, selon cette règle du droit Canonique<note place="margin"
                   resp="author"><quote>« Circa seipsum homo debet dubia interpretari in pejorem
-                    partem secundum illud. Job. 9. v. 28. <quote>« Verebar omnia opera mea. »
-                       »</quote></quote> De homicid. c. ad audientiam.</note>.</p>
+                    partem secundum illud. Job. 9. v. 28. <quote>« Verebar omnia opera mea.
+                       »</quote> »</quote> De homicid. c. ad audientiam.</note>.</p>
               <p>
                 <quote>« Chacun à son égard doit interpréter en mauvaise partie qui est douteux,
                   selon ces paroles de Job : <quote>« Je me défiais de toutes mes œuvres. »
-                     »</quote></quote>
+                     »</quote> »</quote>
               </p>
               <p>Les Confesseurs, et ceux qui conduisent les âmes, en doivent user de même à l’égard
                 de leurs pénitents, selon S. Thomas : <quote>« Lorsque nous devons<seg
@@ -20973,8 +20592,8 @@
             Poèmes Dramatiques ont toujours été notés d’infamie par les lois civiles, et déclarés
             excommuniés par les lois Ecclésiastiques. Ceux qui liront dans ce Traité ces <pb n="491"
               xml:id="p491"/>vérités si constantes, auront sujet de s’étonner qu’un Chrétien ait eu
-            la hardiesse de soutenir par écrit, <quote>que les Poèmes Dramatiques n’ont point été
-              condamnés</quote>.</p>
+            la hardiesse de soutenir par écrit, <quote>« que les Poèmes Dramatiques n’ont point été
+              condamnés »</quote>.</p>
           <p>Que l’on considère la conformité des Décrets du 1. et du 2. Concile d’Arles<note
               place="margin" resp="author"><quote>« De Theatricis qui fideles sunt, placuit eos,
                 quandiu agunt, a communione separari. »</quote> Can. 5. Concil. Arelat. ann. 314. et


### PR DESCRIPTION
## voisenon_moliere_orig : 
- `<bibl>` \ `<ref>` : lien non accepté, mis en commentaire
- `<quote>` : il y a eu embrouille autour du balisage des citations : 
	- dans le texte original, certaines citations sont en italique et d'autre non (s'agit-il de citations imbriquées ?). **Certains passages qui ne sont pas des citations semblent avoir été balisés comme citations**. 
	- **guillemets manquants** de façon aléatoire ce qui ne facilite pas la différenciation des citations entre elles. 
	- mauvais balisage (**citations coupées en plusieurs parties**)  : 
	```xml
	<p><quote>Premier paragraphe de la citation</quote></p>
	<p><quote>Deuxième paragraphe de la citation</quote></p>
	```
	```xml
	<p>Paragraphe en cours : <quote>Début de la citation, premier paragraphe de la citation</quote></p>
	<p><quote>Deuxième paragraphe de la citation</quote></p>
	```
	**plutôt que :**
	```xml
	<quote><p>Premier paragraphe de la citation</p>
	<p>Deuxième paragraphe de la citation</p></quote>
	```
J'ai peur de m'être moi-même embrouillée en corrigeant cela.
- Il faudrait reprendre tout le fichier page par page en vis-à-vis avec le pdf. 